### PR TITLE
[URGENT] 🚨 Security Audit 2026-04-25

### DIFF
--- a/logs/security/2026-04-25.md
+++ b/logs/security/2026-04-25.md
@@ -1,0 +1,189 @@
+# 🛡 Security Audit Report — 2026-04-25
+
+| Item | Value |
+|------|-------|
+| **Date (UTC)** | 2026-04-25 |
+| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| **pip-audit** | 2.10.0 |
+| **bandit** | 1.9.4 (Python 3.11.15) |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---------|----------|------|--------|-----|
+| pip-audit | 0 | 1 | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | 0 | — |
+| outdated (major) | — | — | — | 7 |
+
+---
+
+## 🚨 Critical / High Findings (pip-audit)
+
+| CVE ID | GHSA | Package | Installed | Fix Version |
+|--------|------|---------|-----------|-------------|
+| CVE-2025-69872 | GHSA-w8v5-vhqr-4h9v | diskcache | 5.6.3 | *(no fix released)* |
+
+> **diskcache CVE-2025-69872**: Known vulnerability in diskcache 5.6.3. No upstream fix version is currently available. Monitor the [GHSA-w8v5-vhqr-4h9v](https://github.com/advisories/GHSA-w8v5-vhqr-4h9v) advisory for patch availability.
+
+---
+
+## ⚠ Outdated Dependencies (major version updates only)
+
+| Package | Installed | Latest | Jump |
+|---------|-----------|--------|------|
+| cryptography | 41.0.7 | 47.0.0 | 41 → 47 |
+| setuptools | 68.1.2 | 82.0.1 | 68 → 82 |
+| packaging | 24.0 | 26.2 | 24 → 26 |
+| pip | 24.0 | 26.0.1 | 24 → 26 |
+| launchpadlib | 1.11.0 | 2.1.0 | 1 → 2 |
+| wadllib | 1.3.6 | 2.0.0 | 1 → 2 |
+| xmltodict | 0.13.0 | 1.0.4 | 0 → 1 |
+
+---
+
+## 📋 Bandit Findings (High/Medium only)
+
+All findings are **Medium** severity (0 High).
+
+| # | Issue ID | Severity | Confidence | File | Line | Description |
+|---|----------|----------|------------|------|------|-------------|
+| 1 | B608 | Medium | Medium | `core/conversation_search.py` | 306 | Possible SQL injection via f-string query construction |
+| 2 | B608 | Medium | Low | `core/conversation_search.py` | 368 | Possible SQL injection via f-string query construction |
+| 3 | B310 | Medium | High | `core/github_learner.py` | 180 | `urllib.request.urlopen` — audit for file:/ or custom schemes |
+| 4 | B310 | Medium | High | `core/image_gen.py` | 156 | `urllib.request.urlopen` — audit for file:/ or custom schemes |
+| 5 | B310 | Medium | High | `core/research_agent.py` | 198 | `urllib.request.urlopen` — audit for file:/ or custom schemes |
+| 6 | B601 | Medium | Medium | `core/server_home.py` | 241 | Paramiko `exec_command` — possible shell injection if input unsanitized |
+| 7 | B601 | Medium | Medium | `core/server_home.py` | 265 | Paramiko `exec_command` — possible shell injection if input unsanitized |
+| 8 | B601 | Medium | Medium | `core/server_home.py` | 298 | Paramiko `exec_command("uptime -p")` — static string, low risk |
+| 9 | B601 | Medium | Medium | `core/server_home.py` | 302 | Paramiko `exec_command("df -h / | tail -1")` — static string, low risk |
+| 10 | B601 | Medium | Medium | `core/server_home.py` | 306 | Paramiko `exec_command("free -h | grep Mem | awk ...")` — static string, low risk |
+| 11 | B601 | Medium | Medium | `core/server_home.py` | 312 | Paramiko `exec_command("docker ps ...")` — static string, low risk |
+
+> Lines skipped by `#nosec`: 10 (B608×4, B507×1 and others)
+
+---
+
+## 🔍 Secret Scan
+
+No secrets detected in source files (`.py`, `.json`, `.yaml`, `.yml`) outside `tests/`, `docs/`, `.git/`, `logs/`.
+
+*(Note: test fixtures in `tests/test_pii_properties.py` and `tests/test_high_regression.py` contain dummy key strings — expected and excluded.)*
+
+---
+
+## Delta vs 前日
+
+前日レポート (`logs/security/2026-04-24.md`) が存在しないため差分比較不可。
+**初回スキャン** として記録。
+
+---
+
+## Recommendations (優先度順)
+
+1. **[HIGH] diskcache CVE-2025-69872 の対応**
+   - 修正バージョンが未リリースのため、[GHSA-w8v5-vhqr-4h9v](https://github.com/advisories/GHSA-w8v5-vhqr-4h9v) を継続監視。
+   - 代替キャッシュライブラリ (Redis, dogpile.cache) への移行または diskcache の一時的な使用制限を検討。
+
+2. **[MEDIUM] `core/server_home.py` の Paramiko `exec_command` 入力検証**
+   - `cmd` 変数 (line 265) がユーザ入力由来の場合、allowlist によるサニタイズを実装。
+   - 静的文字列の呼び出し (lines 241, 298, 302, 306, 312) は低リスクだが `# nosec B601` を付与してノイズを抑制。
+
+3. **[MEDIUM] `core/conversation_search.py` の SQL f-string 構築**
+   - line 306 と 368 のクエリは f-string で列名・テーブル名を埋め込んでいる。
+   - 列名・テーブル名が外部入力でないことを確認し、確認できたら `# nosec B608` を付与。
+   - 外部入力の可能性があれば allowlist バリデーションを追加。
+
+4. **[MEDIUM] `cryptography` 41.0.7 → 47.0.0 へのアップグレード**
+   - 6 メジャーバージョン差でセキュリティパッチが多数含まれる。
+   - `pip install --upgrade cryptography` で更新し、回帰テストを実施。
+
+5. **[LOW] `urllib.request.urlopen` の URL スキーム検証**
+   - `core/github_learner.py:180`, `core/image_gen.py:156`, `core/research_agent.py:198` で呼び出し前に URL スキームを `https://` に限定するバリデーションを追加。
+   - `url_guard.py` の既存ユーティリティが使用可能か確認。
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 1 known vulnerability in 1 package
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip list --outdated
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.4.22 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.27.1    sdist
+cryptography       41.0.7    47.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.13      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.0.1    wheel
+PyGObject          3.48.2    3.56.2    sdist
+PyJWT              2.7.0     2.12.1    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+### bandit (text, Medium/High only excerpt)
+
+```
+Run started:2026-04-25 00:24:46.300809+00:00
+
+>> Issue: [B608] Possible SQL injection vector through string-based query construction.
+   Severity: Medium   Confidence: Medium   CWE: CWE-89
+   Location: core/conversation_search.py:306:24
+
+>> Issue: [B608] Possible SQL injection vector through string-based query construction.
+   Severity: Medium   Confidence: Low   CWE: CWE-89
+   Location: core/conversation_search.py:368:12
+
+>> Issue: [B310] Audit url open for permitted schemes.
+   Severity: Medium   Confidence: High   CWE: CWE-22
+   Location: core/github_learner.py:180:17
+
+>> Issue: [B310] Audit url open for permitted schemes.
+   Severity: Medium   Confidence: High   CWE: CWE-22
+   Location: core/image_gen.py:156:13
+
+>> Issue: [B310] Audit url open for permitted schemes.
+   Severity: Medium   Confidence: High   CWE: CWE-22
+   Location: core/research_agent.py:198:17
+
+>> Issue: [B601] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium   CWE: CWE-78
+   Location: core/server_home.py:241, 265, 298, 302, 306, 312
+
+Run metrics:
+  Total issues (by severity): Low: 365, Medium: 11, High: 0
+  Total lines of code: 54471
+  Total lines skipped (#nosec): 0
+  Total potential issues skipped due to #nosec BXXX: 10
+```
+
+</details>


### PR DESCRIPTION
# 🛡 Security Audit Report — 2026-04-25

| Item | Value |
|------|-------|
| **Date (UTC)** | 2026-04-25 |
| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
| **pip-audit** | 2.10.0 |
| **bandit** | 1.9.4 (Python 3.11.15) |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---------|----------|------|--------|-----|
| pip-audit | 0 | **1** | 0 | 0 |
| bandit | 0 | 0 | **11** | 365 |
| secrets | — | — | 0 | — |
| outdated (major) | — | — | — | 7 |

---

## 🚨 Critical / High Findings (pip-audit)

| CVE ID | GHSA | Package | Installed | Fix Version |
|--------|------|---------|-----------|-------------|
| CVE-2025-69872 | GHSA-w8v5-vhqr-4h9v | diskcache | 5.6.3 | *(no fix released)* |

> **diskcache CVE-2025-69872**: Known vulnerability in diskcache 5.6.3. No upstream fix version is currently available. Monitor GHSA-w8v5-vhqr-4h9v for patch availability.

---

## ⚠ Outdated Dependencies (major version updates only)

| Package | Installed | Latest | Jump |
|---------|-----------|--------|------|
| cryptography | 41.0.7 | 47.0.0 | 41 → 47 |
| setuptools | 68.1.2 | 82.0.1 | 68 → 82 |
| packaging | 24.0 | 26.2 | 24 → 26 |
| pip | 24.0 | 26.0.1 | 24 → 26 |
| launchpadlib | 1.11.0 | 2.1.0 | 1 → 2 |
| wadllib | 1.3.6 | 2.0.0 | 1 → 2 |
| xmltodict | 0.13.0 | 1.0.4 | 0 → 1 |

---

## 📋 Bandit Findings (Medium, 11件)

| Issue ID | File | Line | Description |
|----------|------|------|-------------|
| B608 | `core/conversation_search.py` | 306 | SQL injection via f-string query construction |
| B608 | `core/conversation_search.py` | 368 | SQL injection via f-string query construction |
| B310 | `core/github_learner.py` | 180 | `urlopen` — audit for file:/ or custom schemes |
| B310 | `core/image_gen.py` | 156 | `urlopen` — audit for file:/ or custom schemes |
| B310 | `core/research_agent.py` | 198 | `urlopen` — audit for file:/ or custom schemes |
| B601 | `core/server_home.py` | 241 | Paramiko `exec_command` — static string, low risk |
| B601 | `core/server_home.py` | 265 | Paramiko `exec_command(cmd)` — dynamic input, review sanitization |
| B601 | `core/server_home.py` | 298 | Paramiko `exec_command("uptime -p")` — static, low risk |
| B601 | `core/server_home.py` | 302 | Paramiko `exec_command("df -h / \| tail -1")` — static, low risk |
| B601 | `core/server_home.py` | 306 | Paramiko `exec_command("free -h ...")` — static, low risk |
| B601 | `core/server_home.py` | 312 | Paramiko `exec_command("docker ps ...")` — static, low risk |

---

## 🔍 Secret Scan

No secrets detected in source files outside `tests/`.

---

## Delta vs 前日

初回スキャン（`logs/security/2026-04-24.md` 不在のため差分比較なし）。

---

## Recommendations (優先度順)

1. **[HIGH] diskcache CVE-2025-69872** — GHSA-w8v5-vhqr-4h9v を継続監視。修正版リリース次第即時アップグレード。代替ライブラリ (Redis 等) への移行も検討。
2. **[MEDIUM] `core/server_home.py:265` Paramiko exec_command** — 動的 `cmd` 変数に allowlist バリデーションを実装。
3. **[MEDIUM] `core/conversation_search.py:306,368` SQL f-string** — 列名・テーブル名が外部入力でないことを確認し `# nosec B608` を付与、または allowlist バリデーションを追加。
4. **[MEDIUM] cryptography 41 → 47 アップグレード** — 6メジャー分のセキュリティパッチを含む。優先的に更新し回帰テストを実施。
5. **[LOW] `urlopen` スキーム検証** — `url_guard.py` の既存ユーティリティを活用し `https://` のみ許可。

---

- **Audit log**: `logs/security/2026-04-25.md`
- **Related Issue**: #7

*Generated by ai-chan security bot*

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgKG2xKGSrNjx1TJBzfnZa)_