### PR TITLE
[URGENT] 🚨 Security Audit 2026-04-26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,9 @@ data/
 output/
 backups/
 reports/
-logs/
+logs/*
+!logs/security/
+!logs/security/*.md
 *.log
 *.db
 *.db-journal
@@ -76,7 +78,8 @@ AiChan.app/
 *.app/
 
 # ── セキュリティ成果物（漏洩防止のため除外） ─────────
-logs/security/
+logs/security/*
+!logs/security/*.md
 *.sbom.json
 bandit-report.json
 gitleaks-report.json
@@ -98,7 +101,9 @@ data/llm_cache/
 
 # Phase 0 記憶切り離し対策 (2026-04-20)
 data/
-logs/
+logs/*
+!logs/security/
+!logs/security/*.md
 backups/
 output/
 reports/

--- a/logs/security/2026-04-26.md
+++ b/logs/security/2026-04-26.md
@@ -1,0 +1,207 @@
+# 🛡 ai-chan Daily Security Audit — 2026-04-26
+
+| Item | Value |
+|---|---|
+| **Date (UTC)** | 2026-04-26 |
+| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| **pip-audit** | 2.10.0 |
+| **bandit** | 1.9.4 |
+| **Python** | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| pip-audit | 0 | 1 | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | — | 0 (3 test-only) |
+| outdated (major Δ) | — | — | — | 7 |
+
+---
+
+## 🚨 Critical / High Findings
+
+### pip-audit
+
+| CVE | Package | Installed | Fix Version | Description |
+|---|---|---|---|---|
+| CVE-2025-69872 / GHSA-w8v5-vhqr-4h9v | `diskcache` | 5.6.3 | **None available** | DiskCache uses Python pickle for serialization by default. An attacker with write access to the cache directory can achieve **arbitrary code execution** when a victim application deserializes the cached data. |
+
+> ⚠ **No upstream fix released yet.** Mitigate by restricting filesystem ACLs on the cache directory, or migrate to a non-pickle serializer (e.g., JSON/msgpack).
+
+---
+
+## ⚠ Outdated Dependencies (Major Version Updates)
+
+| Package | Installed | Latest | Notes |
+|---|---|---|---|
+| `cryptography` | 41.0.7 | 47.0.0 | **Security-critical library** — 6 major versions behind |
+| `setuptools` | 68.1.2 | 82.0.1 | Build tooling |
+| `pip` | 24.0 | 26.0.1 | Package manager |
+| `packaging` | 24.0 | 26.2 | Version parsing |
+| `launchpadlib` | 1.11.0 | 2.1.0 | Ubuntu Launchpad API |
+| `wadllib` | 1.3.6 | 2.0.0 | WADL parser |
+| `xmltodict` | 0.13.0 | 1.0.4 | XML serialization |
+
+> `cryptography` major update is highest priority — covers OpenSSL binding security patches.
+
+---
+
+## 📋 Bandit Findings (Medium severity, 11 total)
+
+### B608 — Possible SQL Injection (Medium / Medium confidence)
+
+| File | Line | Issue |
+|---|---|---|
+| `core/conversation_search.py` | 306 | f-string interpolation directly into `SELECT` statement — table/column names from config |
+| `core/conversation_search.py` | 368 | f-string building full `SELECT … FROM … WHERE … LIMIT` — over-fetch query |
+
+> Table/column identifiers are from internal config (not user input), reducing actual risk. Consider using an allowlist validator for table/column names.
+
+### B310 — urllib.request.urlopen with unvalidated scheme (Medium / High confidence)
+
+| File | Line | Issue |
+|---|---|---|
+| `core/github_learner.py` | 180 | `urlopen(req, timeout=timeout)` — `# noqa: S310` already annotated |
+| `core/image_gen.py` | 156 | `urlopen(req, timeout=60)` — `# noqa: S310` already annotated |
+| `core/research_agent.py` | 198 | `urlopen(req, timeout=5)` — `# noqa: S310` already annotated |
+
+> All three sites have developer-acknowledged `# noqa: S310` comments but bandit `-ll` still flags them. URL scheme validation (`https://` only) should be added before the `urlopen` calls.
+
+### B601 — Paramiko exec_command (Medium / Medium confidence)
+
+| File | Line | Issue |
+|---|---|---|
+| `core/server_home.py` | 241 | `exec_command("echo ok", timeout=5)` — literal string, safe |
+| `core/server_home.py` | 265 | `exec_command(cmd, timeout=30)` — **`cmd` is caller-supplied** |
+| `core/server_home.py` | 298 | `exec_command("uptime -p", ...)` — literal, safe |
+| `core/server_home.py` | 302 | `exec_command("df -h / \| tail -1", ...)` — literal, safe |
+| `core/server_home.py` | 306 | `exec_command("free -h \| grep Mem \| awk ...", ...)` — literal, safe |
+| `core/server_home.py` | 312 | `exec_command("docker ps --format ...", ...)` — literal, safe |
+
+> Line 265 (`exec_command(cmd, ...)`) is the genuine risk: if `cmd` reaches user-controlled input, it enables remote code execution on the home server. **Audit callers and add an allowlist.**
+
+---
+
+## 🔍 Secret Scan
+
+**0 actual secrets found.**
+
+3 pattern matches detected — all in test fixtures:
+
+| File | Line | Pattern | Assessment |
+|---|---|---|---|
+| `tests/test_high_regression.py` | 77 | `-----BEGIN RSA PRIVATE KEY-----` | Test fixture string (truncated fake key) |
+| `tests/test_pii_properties.py` | 85 | `-----BEGIN RSA PRIVATE KEY-----` | Hypothesis example value |
+| `tests/test_pii_properties.py` | 144 | `-----BEGIN OPENSSH PRIVATE KEY-----` | Hypothesis `@example` decorator |
+
+> No production secrets or API keys detected in source files outside test directories.
+
+---
+
+## Delta vs Previous Day
+
+No previous audit log found (`logs/security/2026-04-25.md` does not exist). This is the **first audit run** — baseline established today.
+
+---
+
+## Recommendations (Priority Order)
+
+1. **[HIGH] Mitigate CVE-2025-69872 (diskcache pickle RCE)**
+   Restrict OS-level write permissions on the diskcache directory to the application user only (`chmod 700`). Evaluate migrating to `diskcache` with a non-pickle serializer or replacing with Redis/SQLite for cache storage. Monitor for an upstream patch release.
+
+2. **[HIGH] Audit `server_home.py:265` — caller-controlled Paramiko `exec_command`**
+   Trace all callers of the method that passes `cmd` to `exec_command`. Introduce a strict command allowlist (e.g., `ALLOWED_CMDS = {"status", "restart", ...}`) and raise `ValueError` for unrecognized commands.
+
+3. **[MEDIUM] Upgrade `cryptography` 41 → 47**
+   This library underpins TLS, JWT signing, and key storage throughout the codebase. Six major versions behind means missing multiple OpenSSL CVE patches. Pin to `cryptography>=47.0.0` in `requirements.txt`.
+
+4. **[MEDIUM] Add URL-scheme validation before `urlopen` calls**
+   In `github_learner.py`, `image_gen.py`, and `research_agent.py`, assert `urllib.parse.urlsplit(url).scheme in ("https",)` before calling `urlopen`. This converts a theoretical SSRF/path-traversal vector into a hard error.
+
+5. **[LOW] Update remaining major-version packages**
+   `setuptools`, `pip`, `packaging`, `xmltodict` — run `pip install --upgrade` for these as part of the next dependency refresh cycle to stay current with security patches.
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 1 known vulnerability in 1 package
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip-audit (JSON excerpt)
+
+```json
+{
+  "name": "diskcache",
+  "version": "5.6.3",
+  "id": "CVE-2025-69872",
+  "aliases": ["GHSA-w8v5-vhqr-4h9v"],
+  "fix_versions": [],
+  "description": "DiskCache (python-diskcache) through 5.6.3 uses Python pickle for serialization by default. An attacker with write access to the cache directory can achieve arbitrary code execution when a victim application deserializes cached data."
+}
+```
+
+### bandit (summary)
+
+```
+Run metrics:
+  Total issues (by severity):
+    Low: 365
+    Medium: 11
+    High: 0
+  Total lines of code: 54471
+```
+
+### Outdated Packages (all 25)
+
+```
+argcomplete 3.1.4 -> 3.6.3
+blinker 1.7.0 -> 1.9.0
+certifi 2026.2.25 -> 2026.4.22
+charset-normalizer 3.4.6 -> 3.4.7
+conan 2.27.0 -> 2.27.1
+cryptography 41.0.7 -> 47.0.0
+dbus-python 1.3.2 -> 1.4.0
+httplib2 0.20.4 -> 0.31.2
+idna 3.11 -> 3.13
+launchpadlib 1.11.0 -> 2.1.0
+lazr.uri 1.0.6 -> 1.0.8
+oauthlib 3.2.2 -> 3.3.1
+packaging 24.0 -> 26.2
+patch-ng 1.18.1 -> 1.19.1
+pip 24.0 -> 26.0.1
+PyGObject 3.48.2 -> 3.56.2
+PyJWT 2.7.0 -> 2.12.1
+pyparsing 3.1.1 -> 3.3.2
+PyYAML 6.0.1 -> 6.0.3
+setuptools 68.1.2 -> 82.0.1
+six 1.16.0 -> 1.17.0
+wadllib 1.3.6 -> 2.0.0
+wheel 0.42.0 -> 0.47.0
+xmltodict 0.13.0 -> 1.0.4
+yq 3.1.0 -> 3.4.3
+```
+
+### Secrets Scan
+
+```
+tests/test_high_regression.py:77: "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKCAQ...\n"
+tests/test_pii_properties.py:85: "-----BEGIN RSA PRIVATE KEY-----"
+tests/test_pii_properties.py:144: @example(sample="-----BEGIN OPENSSH PRIVATE KEY-----")
+```
+
+</details>
+
+---
+
+*Generated by ai-chan security bot · pip-audit 2.10.0 · bandit 1.9.4 · 2026-04-26T00:00:00Z*


### PR DESCRIPTION
> Closes #9

# 🛡 ai-chan Daily Security Audit — 2026-04-26

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---|---|---|---|---|
| pip-audit | 0 | **1** | 0 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| secrets | — | — | — | 0 (3 test-only) |
| outdated (major Δ) | — | — | — | 7 |

## 🚨 High Findings

| CVE | Package | Version | Fix |
|---|---|---|---|
| CVE-2025-69872 / GHSA-w8v5-vhqr-4h9v | `diskcache` | 5.6.3 | **None available yet** |

> **Arbitrary code execution** via pickle deserialization — attacker needs write access to the cache directory.

## ⚠ Top Bandit Findings (Medium)

- **B601** `core/server_home.py:265` — `exec_command(cmd)` with caller-supplied `cmd` via Paramiko (genuine RCE risk on home server)
- **B608** `core/conversation_search.py:306,368` — SQL f-string construction (table/column names from config)
- **B310** `core/github_learner.py`, `image_gen.py`, `research_agent.py` — `urlopen` scheme not validated

## ⚠ Major Outdated Dependencies (7)

`cryptography` 41→47, `setuptools` 68→82, `pip` 24→26, `packaging` 24→26, `launchpadlib` 1→2, `wadllib` 1→2, `xmltodict` 0.13→1.0

## Recommendations

1. **Restrict diskcache directory ACLs** (`chmod 700`) — no upstream patch yet
2. **Audit `server_home.py:265` callers** — add command allowlist before `exec_command(cmd)`
3. **Upgrade `cryptography` to 47.x** — 6 major versions of security patches missing
4. **Add URL scheme validation** before `urlopen` in 3 files
5. **Update remaining major-version packages** in next dependency refresh

---
Full report: `logs/security/2026-04-26.md`

https://claude.ai/code/session_018F6QuXbWaFY2uZeRa3y9aJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018F6QuXbWaFY2uZeRa3y9aJ)_