### PR TITLE
[URGENT] 🚨 Security Audit 2026-05-04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,10 @@ AiChan.app/
 *.app/
 
 # ── セキュリティ成果物（漏洩防止のため除外） ─────────
-logs/security/
+# 監査レポート (Markdown) はリポジトリに記録する — ディレクトリ単位で段階的に解除
+!logs/
+!logs/security/
+!logs/security/*.md
 *.sbom.json
 bandit-report.json
 gitleaks-report.json
@@ -99,6 +102,9 @@ data/llm_cache/
 # Phase 0 記憶切り離し対策 (2026-04-20)
 data/
 logs/
+!logs/
+!logs/security/
+!logs/security/*.md
 backups/
 output/
 reports/

--- a/logs/security/2026-05-04.md
+++ b/logs/security/2026-05-04.md
@@ -1,0 +1,168 @@
+# Security Audit Report — 2026-05-04
+
+| Field | Value |
+|---|---|
+| **Date (UTC)** | 2026-05-04 |
+| **Commit SHA** | 40bb06e |
+| **pip-audit** | 2.10.0 |
+| **bandit** | 1.9.4 |
+| **Python** | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| pip-audit | 0 | 1 | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | — | 0 |
+| outdated | — | — | — | 25 pkg (7 major) |
+
+---
+
+## 🚨 Critical / High Findings
+
+### pip-audit
+
+| CVE / ID | Package | Installed | Fix Versions | Description |
+|---|---|---|---|---|
+| CVE-2025-69872 | diskcache | 5.6.3 | *(none published yet)* | DiskCache uses Python `pickle` for serialization by default. An attacker who can write to the cache can achieve arbitrary code execution via a crafted pickle payload. ([GHSA-w8v5-vhqr-4h9v](https://github.com/advisories/GHSA-w8v5-vhqr-4h9v)) |
+
+**Action required:** No upstream fix version is published yet. Mitigate by:
+1. Restricting write access to the cache directory (filesystem permissions).
+2. Setting `DiskCache(disk=diskcache.JSONDisk)` to avoid pickle entirely where possible.
+3. Monitoring the upstream issue for a patched release.
+
+---
+
+## ⚠ Outdated Dependencies (major updates only)
+
+| Package | Current | Latest | Severity |
+|---|---|---|---|
+| cryptography | 41.0.7 | 47.0.0 | ⚠ Major — many security fixes across 42–47 |
+| setuptools | 68.1.2 | 82.0.1 | ⚠ Major |
+| pip | 24.0 | 26.1 | ⚠ Major |
+| packaging | 24.0 | 26.2 | ⚠ Major |
+| launchpadlib | 1.11.0 | 2.1.0 | ⚠ Major |
+| wadllib | 1.3.6 | 2.0.0 | ⚠ Major |
+| xmltodict | 0.13.0 | 1.0.4 | ⚠ 0.x → 1.0 stable release |
+
+> `cryptography` 41→47 includes multiple CVE patches; upgrade is strongly recommended.
+
+---
+
+## 📋 Bandit Findings (High / Medium only)
+
+**HIGH:** 0  
+**MEDIUM:** 11
+
+| # | File | Line | Issue ID | Issue |
+|---|---|---|---|---|
+| 1 | `core/conversation_search.py` | 306 | B608 | SQL injection vector — f-string query construction |
+| 2 | `core/conversation_search.py` | 368 | B608 | SQL injection vector — f-string query construction |
+| 3 | `core/github_learner.py` | 180 | B310 | `urllib.request.urlopen` — file:/ or custom scheme allowed |
+| 4 | `core/image_gen.py` | 156 | B310 | `urllib.request.urlopen` — file:/ or custom scheme allowed |
+| 5 | `core/research_agent.py` | 198 | B310 | `urllib.request.urlopen` — file:/ or custom scheme allowed |
+| 6 | `core/server_home.py` | 241 | B601 | Paramiko `exec_command` — possible shell injection |
+| 7 | `core/server_home.py` | 265 | B601 | Paramiko `exec_command` — possible shell injection |
+| 8 | `core/server_home.py` | 298 | B601 | Paramiko `exec_command` — possible shell injection |
+| 9 | `core/server_home.py` | 302 | B601 | Paramiko `exec_command` — possible shell injection |
+| 10 | `core/server_home.py` | 306 | B601 | Paramiko `exec_command` — possible shell injection |
+| 11 | `core/server_home.py` | 312 | B601 | Paramiko `exec_command` — possible shell injection |
+
+**Notes:**
+- B608 findings in `conversation_search.py` use column/table name variables, not direct user input. Low exploitability but should be validated.
+- B310 findings have `# noqa: S310` suppression indicating they are intentional; URL schemes should be validated at the callsite.
+- B601 (Paramiko) flagged on `exec_command` calls — commands appear to be hardcoded strings, not user-controlled. Low exploitability.
+
+---
+
+## 🔍 Secret Scan
+
+No secrets detected (0 hits across `*.py`, `*.json`, `*.yaml`, `*.yml`, excluding tests/docs/.git/logs).
+
+---
+
+## Delta vs 前日 (2026-05-03)
+
+前日レポート (`logs/security/2026-05-03.md`) が存在しないため差分なし。本日が初回監査または前回レポートが欠落しています。
+
+---
+
+## Recommendations (優先度順)
+
+1. **[HIGH] diskcache CVE-2025-69872 を即時緩和** — pickle デシリアライゼーション RCE リスク。キャッシュディレクトリへの書き込み権限を OS レベルで制限し、可能な箇所では `JSONDisk` に切り替える。upstream fix リリース次第アップグレード。
+
+2. **[HIGH] cryptography を 47.x へアップグレード** — 41.x から 47.x の間に複数の CVE パッチが含まれる。`requirements.txt` の `cryptography>=47.0.0` への更新と互換性テストを実施。
+
+3. **[MEDIUM] conversation_search.py の SQL クエリ構築を見直す** — B608 (L306, L368) は f-string による動的クエリ。カラム名・テーブル名がユーザー入力由来でないことを確認し、許可リスト検証を追加またはコメントで明示。
+
+4. **[MEDIUM] server_home.py Paramiko exec_command の入力検証を強化** — B601 が 6 箇所で報告。現状はハードコード文字列だが、将来的にコマンド文字列が外部化された場合のリスクを抑えるため、コマンド許可リストと引数サニタイズを実装。
+
+5. **[LOW] その他 outdated 依存関係の定期更新** — pip, setuptools, packaging, launchpadlib, wadllib, xmltodict をメジャーアップ。互換性確認後 `requirements.txt` を更新し、依存更新 PR を月次で自動化することを検討。
+
+---
+
+<details>
+<summary>Raw outputs</summary>
+
+### pip-audit
+
+```
+Found 1 known vulnerability in 1 package
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip list --outdated
+
+```
+argcomplete: 3.1.4 -> 3.6.3
+blinker: 1.7.0 -> 1.9.0
+certifi: 2026.2.25 -> 2026.4.22
+charset-normalizer: 3.4.6 -> 3.4.7
+conan: 2.27.0 -> 2.28.1
+cryptography: 41.0.7 -> 47.0.0
+dbus-python: 1.3.2 -> 1.4.0
+httplib2: 0.20.4 -> 0.31.2
+idna: 3.11 -> 3.13
+launchpadlib: 1.11.0 -> 2.1.0
+lazr.uri: 1.0.6 -> 1.0.8
+oauthlib: 3.2.2 -> 3.3.1
+packaging: 24.0 -> 26.2
+patch-ng: 1.18.1 -> 1.19.1
+pip: 24.0 -> 26.1
+PyGObject: 3.48.2 -> 3.56.2
+PyJWT: 2.7.0 -> 2.12.1
+pyparsing: 3.1.1 -> 3.3.2
+PyYAML: 6.0.1 -> 6.0.3
+setuptools: 68.1.2 -> 82.0.1
+six: 1.16.0 -> 1.17.0
+wadllib: 1.3.6 -> 2.0.0
+wheel: 0.42.0 -> 0.47.0
+xmltodict: 0.13.0 -> 1.0.4
+yq: 3.1.0 -> 3.4.3
+```
+
+### bandit (Medium findings)
+
+```
+core/conversation_search.py:306 [B608] Possible SQL injection vector through string-based query construction.
+core/conversation_search.py:368 [B608] Possible SQL injection vector through string-based query construction.
+core/github_learner.py:180 [B310] Audit url open for permitted schemes.
+core/image_gen.py:156 [B310] Audit url open for permitted schemes.
+core/research_agent.py:198 [B310] Audit url open for permitted schemes.
+core/server_home.py:241 [B601] Possible shell injection via Paramiko call.
+core/server_home.py:265 [B601] Possible shell injection via Paramiko call.
+core/server_home.py:298 [B601] Possible shell injection via Paramiko call.
+core/server_home.py:302 [B601] Possible shell injection via Paramiko call.
+core/server_home.py:306 [B601] Possible shell injection via Paramiko call.
+core/server_home.py:312 [B601] Possible shell injection via Paramiko call.
+
+Total issues: High=0, Medium=11, Low=365
+Total lines scanned: 54471
+```
+
+</details>


### PR DESCRIPTION
# Security Audit Report — 2026-05-04

| Field | Value |
|---|---|
| **Date (UTC)** | 2026-05-04 |
| **Commit SHA** | 40bb06e |
| **pip-audit** | 2.10.0 |
| **bandit** | 1.9.4 |
| **Python** | 3.11.15 |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---|---|---|---|---|
| pip-audit | 0 | 1 | 0 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| secrets | — | — | — | 0 |
| outdated | — | — | — | 25 pkg (7 major) |

---

## 🚨 Critical / High Findings

### pip-audit

| CVE / ID | Package | Installed | Fix Versions | Description |
|---|---|---|---|---|
| CVE-2025-69872 | diskcache | 5.6.3 | *(none published yet)* | DiskCache uses Python `pickle` for serialization by default. An attacker who can write to the cache can achieve arbitrary code execution via a crafted pickle payload. ([GHSA-w8v5-vhqr-4h9v](https://github.com/advisories/GHSA-w8v5-vhqr-4h9v)) |

**Action required:** No upstream fix version is published yet. Mitigate by:
1. Restricting write access to the cache directory (filesystem permissions).
2. Setting `DiskCache(disk=diskcache.JSONDisk)` to avoid pickle entirely where possible.
3. Monitoring the upstream issue for a patched release.

---

## ⚠ Outdated Dependencies (major updates only)

| Package | Current | Latest | Severity |
|---|---|---|---|
| cryptography | 41.0.7 | 47.0.0 | ⚠ Major — many security fixes across 42–47 |
| setuptools | 68.1.2 | 82.0.1 | ⚠ Major |
| pip | 24.0 | 26.1 | ⚠ Major |
| packaging | 24.0 | 26.2 | ⚠ Major |
| launchpadlib | 1.11.0 | 2.1.0 | ⚠ Major |
| wadllib | 1.3.6 | 2.0.0 | ⚠ Major |
| xmltodict | 0.13.0 | 1.0.4 | ⚠ 0.x → 1.0 stable release |

> `cryptography` 41→47 includes multiple CVE patches; upgrade is strongly recommended.

---

## 📋 Bandit Findings (High / Medium only)

**HIGH:** 0  
**MEDIUM:** 11

| # | File | Line | Issue ID | Issue |
|---|---|---|---|---|
| 1 | `core/conversation_search.py` | 306 | B608 | SQL injection vector — f-string query construction |
| 2 | `core/conversation_search.py` | 368 | B608 | SQL injection vector — f-string query construction |
| 3 | `core/github_learner.py` | 180 | B310 | `urllib.request.urlopen` — file:/ or custom scheme allowed |
| 4 | `core/image_gen.py` | 156 | B310 | `urllib.request.urlopen` — file:/ or custom scheme allowed |
| 5 | `core/research_agent.py` | 198 | B310 | `urllib.request.urlopen` — file:/ or custom scheme allowed |
| 6 | `core/server_home.py` | 241 | B601 | Paramiko `exec_command` — possible shell injection |
| 7 | `core/server_home.py` | 265 | B601 | Paramiko `exec_command` — possible shell injection |
| 8 | `core/server_home.py` | 298 | B601 | Paramiko `exec_command` — possible shell injection |
| 9 | `core/server_home.py` | 302 | B601 | Paramiko `exec_command` — possible shell injection |
| 10 | `core/server_home.py` | 306 | B601 | Paramiko `exec_command` — possible shell injection |
| 11 | `core/server_home.py` | 312 | B601 | Paramiko `exec_command` — possible shell injection |

**Notes:**
- B608 findings in `conversation_search.py` use column/table name variables, not direct user input. Low exploitability but should be validated.
- B310 findings have `# noqa: S310` suppression indicating they are intentional; URL schemes should be validated at the callsite.
- B601 (Paramiko) flagged on `exec_command` calls — commands appear to be hardcoded strings, not user-controlled. Low exploitability.

---

## 🔍 Secret Scan

No secrets detected (0 hits across `*.py`, `*.json`, `*.yaml`, `*.yml`, excluding tests/docs/.git/logs).

---

## Delta vs 前日 (2026-05-03)

前日レポート (`logs/security/2026-05-03.md`) が存在しないため差分なし。本日が初回監査または前回レポートが欠落しています。

---

## Recommendations (優先度順)

1. **[HIGH] diskcache CVE-2025-69872 を即時緩和** — pickle デシリアライゼーション RCE リスク。キャッシュディレクトリへの書き込み権限を OS レベルで制限し、可能な箇所では `JSONDisk` に切り替える。upstream fix リリース次第アップグレード。

2. **[HIGH] cryptography を 47.x へアップグレード** — 41.x から 47.x の間に複数の CVE パッチが含まれる。`requirements.txt` の `cryptography>=47.0.0` への更新と互換性テストを実施。

3. **[MEDIUM] conversation_search.py の SQL クエリ構築を見直す** — B608 (L306, L368) は f-string による動的クエリ。カラム名・テーブル名がユーザー入力由来でないことを確認し、許可リスト検証を追加またはコメントで明示。

4. **[MEDIUM] server_home.py Paramiko exec_command の入力検証を強化** — B601 が 6 箇所で報告。現状はハードコード文字列だが、将来的にコマンド文字列が外部化された場合のリスクを抑えるため、コマンド許可リストと引数サニタイズを実装。

5. **[LOW] その他 outdated 依存関係の定期更新** — pip, setuptools, packaging, launchpadlib, wadllib, xmltodict をメジャーアップ。互換性確認後 `requirements.txt` を更新し、依存更新 PR を月次で自動化することを検討。

---

<details>
<summary>Raw outputs</summary>

### pip-audit

```
Found 1 known vulnerability in 1 package
Name      Version ID             Fix Versions
--------- ------- -------------- ------------
diskcache 5.6.3   CVE-2025-69872
```

### pip list --outdated

```
argcomplete: 3.1.4 -> 3.6.3
blinker: 1.7.0 -> 1.9.0
certifi: 2026.2.25 -> 2026.4.22
charset-normalizer: 3.4.6 -> 3.4.7
conan: 2.27.0 -> 2.28.1
cryptography: 41.0.7 -> 47.0.0
dbus-python: 1.3.2 -> 1.4.0
httplib2: 0.20.4 -> 0.31.2
idna: 3.11 -> 3.13
launchpadlib: 1.11.0 -> 2.1.0
lazr.uri: 1.0.6 -> 1.0.8
oauthlib: 3.2.2 -> 3.3.1
packaging: 24.0 -> 26.2
patch-ng: 1.18.1 -> 1.19.1
pip: 24.0 -> 26.1
PyGObject: 3.48.2 -> 3.56.2
PyJWT: 2.7.0 -> 2.12.1
pyparsing: 3.1.1 -> 3.3.2
PyYAML: 6.0.1 -> 6.0.3
setuptools: 68.1.2 -> 82.0.1
six: 1.16.0 -> 1.17.0
wadllib: 1.3.6 -> 2.0.0
wheel: 0.42.0 -> 0.47.0
xmltodict: 0.13.0 -> 1.0.4
yq: 3.1.0 -> 3.4.3
```

### bandit (Medium findings)

```
core/conversation_search.py:306 [B608] Possible SQL injection vector through string-based query construction.
core/conversation_search.py:368 [B608] Possible SQL injection vector through string-based query construction.
core/github_learner.py:180 [B310] Audit url open for permitted schemes.
core/image_gen.py:156 [B310] Audit url open for permitted schemes.
core/research_agent.py:198 [B310] Audit url open for permitted schemes.
core/server_home.py:241 [B601] Possible shell injection via Paramiko call.
core/server_home.py:265 [B601] Possible shell injection via Paramiko call.
core/server_home.py:298 [B601] Possible shell injection via Paramiko call.
core/server_home.py:302 [B601] Possible shell injection via Paramiko call.
core/server_home.py:306 [B601] Possible shell injection via Paramiko call.
core/server_home.py:312 [B601] Possible shell injection via Paramiko call.

Total issues: High=0, Medium=11, Low=365
Total lines scanned: 54471
```

</details>

---
*Generated by ai-chan security bot — 2026-05-04T00:48 UTC*

---
_Generated by [Claude Code](https://claude.ai/code/session_014gjiPhYDQsaAtNCvytTL5J)_