### PR TITLE
[URGENT] 🚨 Security Audit 2026-05-05

### DIFF
--- a/logs/security/2026-05-05.md
+++ b/logs/security/2026-05-05.md
@@ -1,0 +1,180 @@
+# Security Audit Report — 2026-05-05
+
+| Field | Value |
+|-------|-------|
+| Date (UTC) | 2026-05-05 |
+| Commit | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| pip-audit | 2.10.0 |
+| bandit | 1.9.4 |
+| python | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---------|----------|------|--------|-----|
+| pip-audit | 0 | 1 | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | 0 | — | — |
+| outdated (major) | — | — | 7 | — |
+
+---
+
+## 🚨 Critical / High Findings
+
+### CVE-2025-69872 — diskcache 5.6.3 (HIGH)
+
+| Field | Value |
+|-------|-------|
+| CVE | CVE-2025-69872 |
+| GHSA | GHSA-w8v5-vhqr-4h9v |
+| Package | diskcache 5.6.3 |
+| Fix Version | **No fix available** |
+| Description | DiskCache uses Python `pickle` for serialization by default. An attacker with write access to the cache directory can achieve **arbitrary code execution** when a victim application reads from the cache. |
+
+**Immediate mitigations (until a fix is released):**
+1. Restrict filesystem permissions on the DiskCache directory to the application user only.
+2. Do not expose the cache directory to untrusted users or processes.
+3. Consider switching to a non-pickle serializer (`diskcache.Disk(disk_pickle_protocol=-1)` uses JSON where possible) or an alternative caching backend.
+4. Monitor upstream for a patched release.
+
+---
+
+## ⚠ Outdated Dependencies (Major Updates Only)
+
+| Package | Installed | Latest | Delta |
+|---------|-----------|--------|-------|
+| cryptography | 41.0.7 | 48.0.0 | +7 major ⚠ security-critical |
+| setuptools | 68.1.2 | 82.0.1 | +14 major |
+| packaging | 24.0 | 26.2 | +2 major |
+| pip | 24.0 | 26.1.1 | +2 major |
+| launchpadlib | 1.11.0 | 2.1.0 | 1→2 |
+| wadllib | 1.3.6 | 2.0.0 | 1→2 |
+| xmltodict | 0.13.0 | 1.0.4 | 0→1 (stable release) |
+
+> Note: `cryptography` is 7 major versions behind (41→48). Although the installed version (41.0.7) has no reported CVE in the current audit, upgrading a cryptographic library this far behind is strongly recommended.
+
+---
+
+## 📋 Bandit Findings (High / Medium)
+
+**High:** 0  
+**Medium:** 11
+
+### B608 — Possible SQL Injection (CWE-89)
+
+| File | Line | Confidence |
+|------|------|------------|
+| `core/conversation_search.py` | 306 | Medium |
+| `core/conversation_search.py` | 368 | Low |
+
+Both are f-string SQL queries. The column/table names are internal constants and the WHERE clause uses parameterised placeholders; however bandit flags the dynamic `SELECT … FROM` construction. A code review should confirm no user-controlled values flow into these identifiers.
+
+### B310 — urllib.request.urlopen (CWE-22)
+
+| File | Line | Confidence |
+|------|------|------------|
+| `core/github_learner.py` | 180 | High |
+| `core/image_gen.py` | 156 | High |
+| `core/research_agent.py` | 198 | High |
+
+All three already carry `# noqa: S310`. Verify the URL sources are sanitised (HTTPS-only, allowlist validated) before accepting open-redirect or SSRF inputs.
+
+### B601 — Paramiko exec_command (CWE-78)
+
+| File | Line | Confidence |
+|------|------|------------|
+| `core/server_home.py` | 241 | Medium |
+| `core/server_home.py` | 265 | Medium |
+| `core/server_home.py` | 298 | Medium |
+| `core/server_home.py` | 302 | Medium |
+| `core/server_home.py` | 306 | Medium |
+| `core/server_home.py` | 312 | Medium |
+
+Lines 241, 298–312 use hard-coded strings — no injection risk. Line 265 passes a `cmd` variable; confirm it is constructed from a controlled enum/allowlist and never from raw user input.
+
+---
+
+## 🔍 Secret Scan
+
+No secrets detected across `*.py`, `*.json`, `*.yaml`, `*.yml` (excluding `tests/`, `docs/`, `.git/`, `logs/`).
+
+---
+
+## Delta vs Previous Day
+
+No previous report found (`logs/security/2026-05-04.md` does not exist). This is the baseline audit.
+
+---
+
+## Recommendations (Priority Order)
+
+1. **[P1] Mitigate CVE-2025-69872 (diskcache)** — No upstream fix yet. Harden cache directory permissions immediately (`chmod 700`), add a security advisory watch on the package, and evaluate migration to a safer serialization backend.
+2. **[P2] Upgrade cryptography (41.0.7 → 48.0.0)** — Cryptographic libraries should track upstream closely. Seven major versions of gap accumulates risk even without a currently known CVE.
+3. **[P3] Audit `core/server_home.py:265` Paramiko call** — Confirm the `cmd` variable cannot be influenced by user-controlled input; if it can, replace with an allowlist of permitted commands.
+4. **[P4] Review SQL construction in `core/conversation_search.py`** — Add a comment or assertion confirming column/table identifiers are not derived from external input, or refactor to eliminate f-string SQL.
+5. **[P5] Schedule dependency update sprint** — 7 packages have major-version updates pending (see table above). Consider running `pip-compile --upgrade` on a feature branch and validating the test suite.
+
+---
+
+<details>
+<summary>Raw outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 1 known vulnerability in 1 package
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### bandit (summary)
+
+```
+Code scanned:
+    Total lines of code: 54471
+    Total lines skipped (#nosec): 0
+    Total potential issues skipped due to specifically being disabled: 10
+
+Run metrics:
+    Total issues (by severity):
+        Low: 365  Medium: 11  High: 0
+    Total issues (by confidence):
+        Low: 1  Medium: 10  High: 365
+```
+
+### pip list --outdated
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.4.22 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.28.1    wheel
+cryptography       41.0.7    48.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.13      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.1    wheel
+PyGObject          3.48.2    3.56.2    sdist
+PyJWT              2.7.0     2.12.1    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+</details>


### PR DESCRIPTION
# Security Audit Report — 2026-05-05

| Field | Value |
|-------|-------|
| Date (UTC) | 2026-05-05 |
| Commit | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
| pip-audit | 2.10.0 |
| bandit | 1.9.4 |
| python | 3.11.15 |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---------|----------|------|--------|-----|
| pip-audit | 0 | 1 | 0 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| secrets | — | 0 | — | — |
| outdated (major) | — | — | 7 | — |

---

## 🚨 Critical / High Findings

### CVE-2025-69872 — diskcache 5.6.3 (HIGH)

| Field | Value |
|-------|-------|
| CVE | CVE-2025-69872 |
| GHSA | GHSA-w8v5-vhqr-4h9v |
| Package | diskcache 5.6.3 |
| Fix Version | **No fix available** |
| Description | DiskCache uses Python `pickle` for serialization by default. An attacker with write access to the cache directory can achieve **arbitrary code execution** when a victim application reads from the cache. |

**Immediate mitigations (until a fix is released):**
1. Restrict filesystem permissions on the DiskCache directory to the application user only.
2. Do not expose the cache directory to untrusted users or processes.
3. Consider switching to a non-pickle serializer (`diskcache.Disk(disk_pickle_protocol=-1)` uses JSON where possible) or an alternative caching backend.
4. Monitor upstream for a patched release.

---

## ⚠ Outdated Dependencies (Major Updates Only)

| Package | Installed | Latest | Delta |
|---------|-----------|--------|-------|
| cryptography | 41.0.7 | 48.0.0 | +7 major ⚠ security-critical |
| setuptools | 68.1.2 | 82.0.1 | +14 major |
| packaging | 24.0 | 26.2 | +2 major |
| pip | 24.0 | 26.1.1 | +2 major |
| launchpadlib | 1.11.0 | 2.1.0 | 1→2 |
| wadllib | 1.3.6 | 2.0.0 | 1→2 |
| xmltodict | 0.13.0 | 1.0.4 | 0→1 (stable release) |

> Note: `cryptography` is 7 major versions behind (41→48). Although the installed version (41.0.7) has no reported CVE in the current audit, upgrading a cryptographic library this far behind is strongly recommended.

---

## 📋 Bandit Findings (High / Medium)

**High:** 0  
**Medium:** 11

### B608 — Possible SQL Injection (CWE-89)

| File | Line | Confidence |
|------|------|------------|
| `core/conversation_search.py` | 306 | Medium |
| `core/conversation_search.py` | 368 | Low |

Both are f-string SQL queries. The column/table names are internal constants and the WHERE clause uses parameterised placeholders; however bandit flags the dynamic `SELECT … FROM` construction. A code review should confirm no user-controlled values flow into these identifiers.

### B310 — urllib.request.urlopen (CWE-22)

| File | Line | Confidence |
|------|------|------------|
| `core/github_learner.py` | 180 | High |
| `core/image_gen.py` | 156 | High |
| `core/research_agent.py` | 198 | High |

All three already carry `# noqa: S310`. Verify the URL sources are sanitised (HTTPS-only, allowlist validated) before accepting open-redirect or SSRF inputs.

### B601 — Paramiko exec_command (CWE-78)

| File | Line | Confidence |
|------|------|------------|
| `core/server_home.py` | 241 | Medium |
| `core/server_home.py` | 265 | Medium |
| `core/server_home.py` | 298 | Medium |
| `core/server_home.py` | 302 | Medium |
| `core/server_home.py` | 306 | Medium |
| `core/server_home.py` | 312 | Medium |

Lines 241, 298–312 use hard-coded strings — no injection risk. Line 265 passes a `cmd` variable; confirm it is constructed from a controlled enum/allowlist and never from raw user input.

---

## 🔍 Secret Scan

No secrets detected across `*.py`, `*.json`, `*.yaml`, `*.yml` (excluding `tests/`, `docs/`, `.git/`, `logs/`).

---

## Delta vs Previous Day

No previous report found (`logs/security/2026-05-04.md` does not exist). This is the baseline audit.

---

## Recommendations (Priority Order)

1. **[P1] Mitigate CVE-2025-69872 (diskcache)** — No upstream fix yet. Harden cache directory permissions immediately (`chmod 700`), add a security advisory watch on the package, and evaluate migration to a safer serialization backend.
2. **[P2] Upgrade cryptography (41.0.7 → 48.0.0)** — Cryptographic libraries should track upstream closely. Seven major versions of gap accumulates risk even without a currently known CVE.
3. **[P3] Audit `core/server_home.py:265` Paramiko call** — Confirm the `cmd` variable cannot be influenced by user-controlled input; if it can, replace with an allowlist of permitted commands.
4. **[P4] Review SQL construction in `core/conversation_search.py`** — Add a comment or assertion confirming column/table identifiers are not derived from external input, or refactor to eliminate f-string SQL.
5. **[P5] Schedule dependency update sprint** — 7 packages have major-version updates pending (see table above). Consider running `pip-compile --upgrade` on a feature branch and validating the test suite.

---

Full report: `logs/security/2026-05-05.md`

Related issue: https://github.com/FIshota/AI/issues/27

---
_Generated by [Claude Code](https://claude.ai/code/session_012G1mhqafzmMbq2NXY8dZW9)_