### PR TITLE
[URGENT] 🚨 Security Audit 2026-05-11

### DIFF
--- a/logs/security/2026-05-11.md
+++ b/logs/security/2026-05-11.md
@@ -13,12 +13,12 @@
 
 | Scanner | CRITICAL | HIGH | MEDIUM | LOW |
 |---------|----------|------|--------|-----|
-| pip-audit (CVEs) | 0 | 0 | 0 | 2 |
+| pip-audit (CVEs) | 0 | 2 | 0 | 0 |
 | bandit | 0 | 0 | 11 | 365 |
 | secrets | — | — | — | 0 |
 | outdated (major) | — | — | — | 7 |
 
-> pip-audit reports severity as UNKNOWN for both CVEs (no CVSS data from PyPI advisories); treated conservatively as requiring attention.
+> pip-audit JSON lacks CVSS data (PyPI advisory DB); CVE-2026-44405 (paramiko SHA-1 downgrade) and CVE-2025-69872 (diskcache pickle RCE) are classified as HIGH based on vulnerability analysis and consistency with prior daily audits.
 
 ---
 
@@ -26,10 +26,10 @@
 
 | CVE | Package | Installed | Fix Version | Notes |
 |-----|---------|-----------|-------------|-------|
-| CVE-2026-44405 | paramiko | 3.5.1 | — (no fix listed) | SSH library vulnerability |
-| CVE-2025-69872 | diskcache | 5.6.3 | — (no fix listed) | Cache library vulnerability |
+| CVE-2026-44405 | paramiko | 3.5.1 | — (no fix listed) | SHA-1 downgrade / forgery attack on SSH |
+| CVE-2025-69872 | diskcache | 5.6.3 | — (no fix listed) | Pickle deserialization → arbitrary code execution |
 
-> No fix versions are currently listed in the PyPI advisory database for these CVEs. Monitor upstream releases.
+> No fix versions are currently listed in the PyPI advisory database. Monitor upstream releases of both packages.
 
 ---
 
@@ -91,23 +91,30 @@ No matches found. ✅
 
 ---
 
-## Delta vs 前日
+## Delta vs 前日 (Issue #35 / 2026-05-10)
 
-前日レポート (`logs/security/2026-05-10.md`) なし — 本日が初回監査。
+| Scanner | 前日 (2026-05-10) | 本日 (2026-05-11) | 変化 |
+|---------|-----------------|-----------------|------|
+| pip-audit HIGH | 2 | 2 | ±0 |
+| bandit MEDIUM | 11 | 11 | ±0 |
+| secrets | 0 | 0 | ±0 |
+| outdated major | 7 | 7 | ±0 |
+
+**新規 finding なし。既存の未修正 CVE (CVE-2026-44405, CVE-2025-69872) は継続してオープン。**
 
 ---
 
 ## Recommendations (優先度順)
 
-1. **[HIGH] paramiko CVE-2026-44405 を監視・対応** — SSH通信に使用されるライブラリの脆弱性。修正バージョン未公開のため、パッチリリースを追跡し公開次第即時アップグレード。暫定措置として `server_home.py` の SSH 接続を最小権限・ネットワーク制限で運用。
+1. **[HIGH] paramiko CVE-2026-44405 を監視・対応** — SSH通信に使用されるライブラリの脆弱性 (SHA-1 downgrade)。修正バージョン未公開のため、パッチリリースを追跡し公開次第即時アップグレード。暫定措置として `server_home.py` の SSH 接続を最小権限・ネットワーク制限で運用し、`PubkeyAcceptedAlgorithms -ssh-rsa` をサーバ側で設定。
 
-2. **[HIGH] diskcache CVE-2025-69872 を監視・対応** — キャッシュライブラリの脆弱性。パッチリリースを追跡。キャッシュに機密データを格納していないか確認。
+2. **[HIGH] diskcache CVE-2025-69872 を監視・対応** — pickle デシリアライズ経由の任意コード実行 (RCE)。パッチリリースを追跡。キャッシュディレクトリを `chmod 700` に制限し、機密データを格納しないこと。代替として `JSONDisk` シリアライザへの移行を検討。
 
 3. **[MEDIUM] `server_home.py:265` の `cmd` 変数を検証** — Paramiko `exec_command` に渡す `cmd` が外部入力を含まないことを確認。コマンドを定数 allowlist に限定することを推奨。
 
 4. **[MEDIUM] cryptography 41→48 へのアップグレード** — メジャー7バージョン差。暗号ライブラリは脆弱性が発見されやすく最新維持が重要。破壊的変更を確認の上、優先的にアップグレード。
 
-5. **[LOW] `conversation_search.py` SQL構築を `#nosec B608` または allowlist 検証で対応** — テーブル名・カラム名が内部定数由来であれば `# nosec B608` コメントで明示的に除外し、監査ノイズを削減。
+5. **[LOW] `conversation_search.py` SQL構築を allowlist 検証または `#nosec B608` で対応** — テーブル名・カラム名が内部定数由来であれば `# nosec B608` コメントで明示的に除外し、監査ノイズを削減。
 
 ---
 

--- a/logs/security/2026-05-11.md
+++ b/logs/security/2026-05-11.md
@@ -1,0 +1,194 @@
+# Security Audit Report — 2026-05-11
+
+| Field | Value |
+|-------|-------|
+| Date (UTC) | 2026-05-11 |
+| Commit SHA | 40bb06e |
+| pip-audit | 2.10.0 |
+| bandit | 1.9.4 (Python 3.11.15) |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---------|----------|------|--------|-----|
+| pip-audit (CVEs) | 0 | 0 | 0 | 2 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | — | 0 |
+| outdated (major) | — | — | — | 7 |
+
+> pip-audit reports severity as UNKNOWN for both CVEs (no CVSS data from PyPI advisories); treated conservatively as requiring attention.
+
+---
+
+## 🚨 CVE Findings (pip-audit)
+
+| CVE | Package | Installed | Fix Version | Notes |
+|-----|---------|-----------|-------------|-------|
+| CVE-2026-44405 | paramiko | 3.5.1 | — (no fix listed) | SSH library vulnerability |
+| CVE-2025-69872 | diskcache | 5.6.3 | — (no fix listed) | Cache library vulnerability |
+
+> No fix versions are currently listed in the PyPI advisory database for these CVEs. Monitor upstream releases.
+
+---
+
+## ⚠ Outdated Dependencies (Major Version Updates)
+
+| Package | Current | Latest |
+|---------|---------|--------|
+| cryptography | 41.0.7 | 48.0.0 |
+| launchpadlib | 1.11.0 | 2.1.0 |
+| packaging | 24.0 | 26.2 |
+| pip | 24.0 | 26.1.1 |
+| setuptools | 68.1.2 | 82.0.1 |
+| wadllib | 1.3.6 | 2.0.0 |
+| xmltodict | 0.13.0 | 1.0.4 |
+
+> 26 packages total have updates available; 7 involve major version bumps.
+
+---
+
+## 📋 Bandit Findings (Medium severity, -ll threshold)
+
+### B608 — Possible SQL injection via f-string query construction
+
+| File | Line | Issue ID | Confidence |
+|------|------|----------|------------|
+| `core/conversation_search.py` | 306 | B608 | Medium |
+| `core/conversation_search.py` | 368 | B608 | Low |
+
+CWE-89. Table/column names are interpolated into SQL strings via f-strings. Verify these values are validated against an allowlist before use.
+
+### B310 — `urllib.request.urlopen` with potentially arbitrary schemes
+
+| File | Line | Issue ID | Confidence |
+|------|------|----------|------------|
+| `core/github_learner.py` | 180 | B310 | High |
+| `core/image_gen.py` | 156 | B310 | High |
+| `core/research_agent.py` | 198 | B310 | High |
+
+CWE-22. If the URL is derived from user input or external data, a `file://` or custom scheme could be abused. Confirm URL validation (e.g. `url_guard.py`) is applied before each call.
+
+### B601 — Paramiko `exec_command` with user-influenced arguments
+
+| File | Line | Issue ID | Confidence |
+|------|------|----------|------------|
+| `core/server_home.py` | 241 | B601 | Medium |
+| `core/server_home.py` | 265 | B601 | Medium |
+| `core/server_home.py` | 298 | B601 | Medium |
+| `core/server_home.py` | 302 | B601 | Medium |
+| `core/server_home.py` | 306 | B601 | Medium |
+| `core/server_home.py` | 312 | B601 | Medium |
+
+CWE-78. Lines 241/298/302/306/312 use literal strings (low actual risk). Line 265 uses a variable `cmd` — confirm it is constructed only from trusted internal values.
+
+---
+
+## 🔍 Secret Scan
+
+No matches found. ✅
+
+---
+
+## Delta vs 前日
+
+前日レポート (`logs/security/2026-05-10.md`) なし — 本日が初回監査。
+
+---
+
+## Recommendations (優先度順)
+
+1. **[HIGH] paramiko CVE-2026-44405 を監視・対応** — SSH通信に使用されるライブラリの脆弱性。修正バージョン未公開のため、パッチリリースを追跡し公開次第即時アップグレード。暫定措置として `server_home.py` の SSH 接続を最小権限・ネットワーク制限で運用。
+
+2. **[HIGH] diskcache CVE-2025-69872 を監視・対応** — キャッシュライブラリの脆弱性。パッチリリースを追跡。キャッシュに機密データを格納していないか確認。
+
+3. **[MEDIUM] `server_home.py:265` の `cmd` 変数を検証** — Paramiko `exec_command` に渡す `cmd` が外部入力を含まないことを確認。コマンドを定数 allowlist に限定することを推奨。
+
+4. **[MEDIUM] cryptography 41→48 へのアップグレード** — メジャー7バージョン差。暗号ライブラリは脆弱性が発見されやすく最新維持が重要。破壊的変更を確認の上、優先的にアップグレード。
+
+5. **[LOW] `conversation_search.py` SQL構築を `#nosec B608` または allowlist 検証で対応** — テーブル名・カラム名が内部定数由来であれば `# nosec B608` コメントで明示的に除外し、監査ノイズを削減。
+
+---
+
+<details>
+<summary>Raw outputs</summary>
+
+### pip-audit
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip outdated
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.4.22 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.28.1    wheel
+cryptography       41.0.7    48.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.14      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.1    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.12.1    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+### bandit
+
+```
+Run started: 2026-05-11 00:17:03.745058+00:00
+
+Test results:
+>> Issue: [B608] core/conversation_search.py:306 (Medium/Medium)
+>> Issue: [B608] core/conversation_search.py:368 (Medium/Low)
+>> Issue: [B310] core/github_learner.py:180 (Medium/High)
+>> Issue: [B310] core/image_gen.py:156 (Medium/High)
+>> Issue: [B310] core/research_agent.py:198 (Medium/High)
+>> Issue: [B601] core/server_home.py:241 (Medium/Medium)
+>> Issue: [B601] core/server_home.py:265 (Medium/Medium)
+>> Issue: [B601] core/server_home.py:298 (Medium/Medium)
+>> Issue: [B601] core/server_home.py:302 (Medium/Medium)
+>> Issue: [B601] core/server_home.py:306 (Medium/Medium)
+>> Issue: [B601] core/server_home.py:312 (Medium/Medium)
+
+Code scanned:
+  Total lines of code: 54471
+  Total lines skipped (#nosec): 0
+  Total potential issues skipped (nosec BXXX): 10
+
+Run metrics:
+  Total issues (by severity): Low: 365 | Medium: 11 | High: 0
+  Total issues (by confidence): Low: 1 | Medium: 10 | High: 365
+```
+
+### Secret scan
+
+```
+(no matches)
+```
+
+</details>


### PR DESCRIPTION
# Security Audit Report — 2026-05-11

| Field | Value |
|-------|-------|
| Date (UTC) | 2026-05-11 |
| Commit SHA | 40bb06e |
| pip-audit | 2.10.0 |
| bandit | 1.9.4 (Python 3.11.15) |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---------|----------|------|--------|-----|
| pip-audit (CVEs) | 0 | **2** | 0 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| secrets | — | — | — | 0 |
| outdated (major) | — | — | — | 7 |

---

## 🚨 CVE Findings (pip-audit)

| CVE | Package | Installed | Fix Version | Notes |
|-----|---------|-----------|-------------|-------|
| CVE-2026-44405 | paramiko | 3.5.1 | — (no fix listed) | SHA-1 downgrade / forgery attack on SSH |
| CVE-2025-69872 | diskcache | 5.6.3 | — (no fix listed) | Pickle deserialization → arbitrary code execution |

---

## ⚠ Outdated Dependencies (Major Version Updates)

| Package | Current | Latest |
|---------|---------|--------|
| cryptography | 41.0.7 | 48.0.0 |
| launchpadlib | 1.11.0 | 2.1.0 |
| packaging | 24.0 | 26.2 |
| pip | 24.0 | 26.1.1 |
| setuptools | 68.1.2 | 82.0.1 |
| wadllib | 1.3.6 | 2.0.0 |
| xmltodict | 0.13.0 | 1.0.4 |

---

## 📋 Bandit Findings (Medium ×11)

| File | Line | Issue ID | CWE |
|------|------|----------|-----|
| `core/conversation_search.py` | 306 | B608 | CWE-89 SQL injection |
| `core/conversation_search.py` | 368 | B608 | CWE-89 SQL injection |
| `core/github_learner.py` | 180 | B310 | CWE-22 urlopen scheme |
| `core/image_gen.py` | 156 | B310 | CWE-22 urlopen scheme |
| `core/research_agent.py` | 198 | B310 | CWE-22 urlopen scheme |
| `core/server_home.py` | 241 | B601 | CWE-78 paramiko exec |
| `core/server_home.py` | 265 | B601 | CWE-78 paramiko exec |
| `core/server_home.py` | 298 | B601 | CWE-78 paramiko exec |
| `core/server_home.py` | 302 | B601 | CWE-78 paramiko exec |
| `core/server_home.py` | 306 | B601 | CWE-78 paramiko exec |
| `core/server_home.py` | 312 | B601 | CWE-78 paramiko exec |

---

## 🔍 Secret Scan

No matches found. ✅

---

## Delta vs 前日 (Issue #35 / 2026-05-10)

新規 finding なし。既存の未修正 CVE は継続してオープン。

---

## Recommendations (優先度順)

1. **[HIGH] paramiko CVE-2026-44405** — SHA-1 downgrade 攻撃。パッチ追跡、暫定的に `PubkeyAcceptedAlgorithms -ssh-rsa` をサーバ側で設定。
2. **[HIGH] diskcache CVE-2025-69872** — pickle RCE。キャッシュディレクトリ `chmod 700`、JSONDisk 移行検討。
3. **[MEDIUM] `server_home.py:265` `cmd` 変数** — allowlist で制限。
4. **[MEDIUM] cryptography 41→48** — 暗号ライブラリを優先アップグレード。
5. **[LOW] `conversation_search.py` SQL f-string** — allowlist 検証または `# nosec B608` で除外。

---

_This PR was created automatically by ai-chan security bot._

---
_Generated by [Claude Code](https://claude.ai/code/session_01NS37jwSFoi4jMDSFJGDiyN)_