### PR TITLE
[URGENT] 🚨 Security Audit 2026-05-12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,10 @@ AiChan.app/
 
 # ── セキュリティ成果物（漏洩防止のため除外） ─────────
 logs/security/
+# 日次監査レポート (Markdown サマリのみ) は追跡対象
+!logs/
+!logs/security/
+!logs/security/*.md
 *.sbom.json
 bandit-report.json
 gitleaks-report.json
@@ -116,3 +120,9 @@ bench/data_cache/
 
 # INTERNAL: Ai の存在を公開リポジトリに出さない
 docs/VISION_INTERNAL.md
+
+# ── 日次セキュリティ監査レポート (Markdown サマリのみ追跡) ──
+# 上位の logs/ ルールを上書きするため末尾に配置
+!logs/
+!logs/security/
+!logs/security/*.md

--- a/logs/security/2026-05-12.md
+++ b/logs/security/2026-05-12.md
@@ -1,0 +1,231 @@
+# 🛡 Security Audit Report — 2026-05-12
+
+| Item | Value |
+|------|-------|
+| **Date (UTC)** | 2026-05-12 |
+| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| **pip-audit** | 2.10.0 |
+| **bandit** | 1.9.4 |
+| **Python** | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---------|----------|------|--------|-----|
+| pip-audit (CVE) | 1 | 1 | 0 | 0 |
+| bandit (SAST) | 0 | 0 | 11 | 365 |
+| Secret Scan | — | — | — | 0 |
+| Outdated Deps | — | — | — | 27 total / 7 major |
+
+---
+
+## 🚨 Critical / High Findings (pip-audit)
+
+### CVE-2025-69872 — diskcache 5.6.3 (CRITICAL)
+
+- **Package:** `diskcache` 5.6.3
+- **Alias:** GHSA-w8v5-vhqr-4h9v
+- **Fix Version:** No patched version available yet
+- **Description:** DiskCache uses Python `pickle` for serialization by default. An attacker with **write access to the cache directory** can achieve **arbitrary code execution** when a victim application reads from the cache.
+- **Risk:** If the cache directory is shared, world-writable, or accessible via a path-traversal, an adversary can inject a malicious pickle payload.
+
+### CVE-2026-44405 — paramiko 3.5.1 (HIGH)
+
+- **Package:** `paramiko` 3.5.1
+- **Alias:** GHSA-r374-rxx8-8654
+- **Fix Version:** No patched version available yet (fixed upstream in commit a448945)
+- **Description:** `rsakey.py` allows the SHA-1 algorithm, which is considered cryptographically weak and is deprecated for SSH key signing.
+- **Risk:** Connections that negotiate SHA-1 may be vulnerable to downgrade or collision attacks. Relevant in `core/server_home.py` (SSH remote management).
+
+---
+
+## ⚠ Outdated Dependencies (major version changes only)
+
+| Package | Current | Latest | Notes |
+|---------|---------|--------|-------|
+| `cryptography` | 41.0.7 | 48.0.0 | **7 major versions behind** — security-critical library |
+| `setuptools` | 68.1.2 | 82.0.1 | Build toolchain |
+| `packaging` | 24.0 | 26.2 | |
+| `pip` | 24.0 | 26.1.1 | |
+| `wadllib` | 1.3.6 | 2.0.0 | |
+| `xmltodict` | 0.13.0 | 1.0.4 | |
+| `launchpadlib` | 1.11.0 | 2.1.0 | |
+
+> ⚠ `cryptography` 41 → 48 is especially noteworthy: multiple CVEs were addressed in intermediate versions.
+
+---
+
+## 📋 Bandit Findings (Medium severity — 11 issues)
+
+| File | Line | Issue ID | Severity | Description |
+|------|------|----------|----------|-------------|
+| `core/conversation_search.py` | 306 | B608 | Medium | Possible SQL injection via f-string query construction |
+| `core/conversation_search.py` | 368 | B608 | Medium | Possible SQL injection via f-string query construction |
+| `core/github_learner.py` | 180 | B310 | Medium | `urllib.request.urlopen` — unvalidated URL scheme |
+| `core/image_gen.py` | 156 | B310 | Medium | `urllib.request.urlopen` — unvalidated URL scheme |
+| `core/research_agent.py` | 198 | B310 | Medium | `urllib.request.urlopen` — unvalidated URL scheme |
+| `core/server_home.py` | 241 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
+| `core/server_home.py` | 265 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
+| `core/server_home.py` | 298 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
+| `core/server_home.py` | 302 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
+| `core/server_home.py` | 306 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
+| `core/server_home.py` | 312 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
+
+> `bandit` also flagged 365 Low-severity issues (informational); not listed here.
+
+---
+
+## 🔍 Secret Scan
+
+No secrets detected. 0 matches for patterns: `sk-*`, `ghp_*`, `AKIA*`, `-----BEGIN * PRIVATE KEY-----`.
+
+---
+
+## Delta vs 前日
+
+前日 (`2026-05-11`) のレポートは存在しないため差分比較不可。本日が初回レポートとなります。
+
+---
+
+## Recommendations (優先度順)
+
+1. **[P0] diskcache キャッシュディレクトリのパーミッション強化** — CVE-2025-69872 のパッチが未リリースのため、当面の回避策としてキャッシュディレクトリを `chmod 700`（プロセスオーナー専用）に制限し、`DISKCACHE_SIZE_LIMIT` 等のオプションで書き込み元を限定すること。また `diskcache.Cache(disk=diskcache.JSONDisk)` への切り替えを検討。
+
+2. **[P0] paramiko の SHA-1 無効化** — CVE-2026-44405 のパッチが未リリースのため、`core/server_home.py` の SSH 接続設定で `disabled_algorithms={'keys': ['rsa-sha2-256'], 'pubkeys': ['rsa-sha2-256']}` ではなく `preferred_pubkeys=('ecdsa-sha2-nistp256', 'ssh-ed25519')` を指定して SHA-1 ネゴシエーションを排除。
+
+3. **[P1] cryptography ライブラリのアップグレード** — 現在 v41.0.7 は v48.0.0 より 7 メジャーバージョン古く、複数の CVE が修正済み。`pip install --upgrade cryptography` を実行しテストを通過させること。
+
+4. **[P2] `core/conversation_search.py` の SQL クエリをパラメータ化** — B608 (SQL injection) の 2 箇所 (line 306, 368) は f-string でテーブル名・列名を展開している。テーブル名は allowlist チェック済みであれば `# nosec B608` コメントで明示的に抑制し、それ以外はパラメータバインディングに移行すること。
+
+5. **[P3] `urllib.request.urlopen` 呼び出しの URL スキーム検証強化** — B310 の 3 箇所 (`github_learner.py:180`, `image_gen.py:156`, `research_agent.py:198`) は `https://` のみを許可するスキームチェックを呼び出し前に追加すること（例: `assert url.startswith('https://')`）。
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (plain text)
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip list --outdated
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.4.22 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.28.1    wheel
+cryptography       41.0.7    48.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.14      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.1    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.12.1    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+requests           2.33.1    2.34.0    wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+### bandit (plain text)
+
+```
+Run started:2026-05-12 00:06:37.437664+00:00
+
+Test results:
+>> Issue: [B608] Possible SQL injection vector through string-based query construction.
+   Severity: Medium   Confidence: Medium   CWE: CWE-89
+   Location: core/conversation_search.py:306
+
+>> Issue: [B608] Possible SQL injection vector through string-based query construction.
+   Severity: Medium   Confidence: Low   CWE: CWE-89
+   Location: core/conversation_search.py:368
+
+>> Issue: [B310] Audit url open for permitted schemes.
+   Severity: Medium   Confidence: High   CWE: CWE-22
+   Location: core/github_learner.py:180
+
+>> Issue: [B310] Audit url open for permitted schemes.
+   Severity: Medium   Confidence: High   CWE: CWE-22
+   Location: core/image_gen.py:156
+
+>> Issue: [B310] Audit url open for permitted schemes.
+   Severity: Medium   Confidence: High   CWE: CWE-22
+   Location: core/research_agent.py:198
+
+>> Issue: [B601] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium   CWE: CWE-78
+   Location: core/server_home.py:241
+
+>> Issue: [B601] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium   CWE: CWE-78
+   Location: core/server_home.py:265
+
+>> Issue: [B601] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium   CWE: CWE-78
+   Location: core/server_home.py:298
+
+>> Issue: [B601] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium   CWE: CWE-78
+   Location: core/server_home.py:302
+
+>> Issue: [B601] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium   CWE: CWE-78
+   Location: core/server_home.py:306
+
+>> Issue: [B601] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium   CWE: CWE-78
+   Location: core/server_home.py:312
+
+Run metrics:
+  Total lines of code: 54471
+  Total issues (by severity): High: 0, Medium: 11, Low: 365
+```
+
+### pip-audit (JSON)
+
+```json
+[
+  {
+    "pkg": "paramiko",
+    "version": "3.5.1",
+    "id": "CVE-2026-44405",
+    "fix": [],
+    "aliases": ["GHSA-r374-rxx8-8654"],
+    "description": "In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm."
+  },
+  {
+    "pkg": "diskcache",
+    "version": "5.6.3",
+    "id": "CVE-2025-69872",
+    "fix": [],
+    "aliases": ["GHSA-w8v5-vhqr-4h9v"],
+    "description": "DiskCache (python-diskcache) through 5.6.3 uses Python pickle for serialization by default. An attacker with write access to the cache directory can achieve arbitrary code execution when a victim application reads from the cache."
+  }
+]
+```
+
+</details>


### PR DESCRIPTION
> 🤖 ai-chan security bot による自動監査レポート | Related Issue: #39

# 🛡 Security Audit Report — 2026-05-12

| Item | Value |
|------|-------|
| **Date (UTC)** | 2026-05-12 |
| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
| **pip-audit** | 2.10.0 |
| **bandit** | 1.9.4 |
| **Python** | 3.11.15 |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---------|----------|------|--------|-----|
| pip-audit (CVE) | 1 | 1 | 0 | 0 |
| bandit (SAST) | 0 | 0 | 11 | 365 |
| Secret Scan | — | — | — | 0 |
| Outdated Deps | — | — | — | 27 total / 7 major |

---

## 🚨 Critical / High Findings (pip-audit)

### CVE-2025-69872 — diskcache 5.6.3 (CRITICAL)

- **Package:** `diskcache` 5.6.3
- **Alias:** GHSA-w8v5-vhqr-4h9v
- **Fix Version:** No patched version available yet
- **Description:** DiskCache uses Python `pickle` for serialization by default. An attacker with **write access to the cache directory** can achieve **arbitrary code execution** when a victim application reads from the cache.
- **Risk:** If the cache directory is shared, world-writable, or accessible via a path-traversal, an adversary can inject a malicious pickle payload.

### CVE-2026-44405 — paramiko 3.5.1 (HIGH)

- **Package:** `paramiko` 3.5.1
- **Alias:** GHSA-r374-rxx8-8654
- **Fix Version:** No patched version available yet (fixed upstream in commit a448945)
- **Description:** `rsakey.py` allows the SHA-1 algorithm, which is considered cryptographically weak and is deprecated for SSH key signing.
- **Risk:** Connections that negotiate SHA-1 may be vulnerable to downgrade or collision attacks. Relevant in `core/server_home.py` (SSH remote management).

---

## ⚠ Outdated Dependencies (major version changes only)

| Package | Current | Latest | Notes |
|---------|---------|--------|-------|
| `cryptography` | 41.0.7 | 48.0.0 | **7 major versions behind** — security-critical library |
| `setuptools` | 68.1.2 | 82.0.1 | Build toolchain |
| `packaging` | 24.0 | 26.2 | |
| `pip` | 24.0 | 26.1.1 | |
| `wadllib` | 1.3.6 | 2.0.0 | |
| `xmltodict` | 0.13.0 | 1.0.4 | |
| `launchpadlib` | 1.11.0 | 2.1.0 | |

> ⚠ `cryptography` 41 → 48 は特に重要：中間バージョンで複数の CVE が修正されています。

---

## 📋 Bandit Findings (Medium severity — 11 issues)

| File | Line | Issue ID | Severity | Description |
|------|------|----------|----------|-------------|
| `core/conversation_search.py` | 306 | B608 | Medium | Possible SQL injection via f-string query construction |
| `core/conversation_search.py` | 368 | B608 | Medium | Possible SQL injection via f-string query construction |
| `core/github_learner.py` | 180 | B310 | Medium | `urllib.request.urlopen` — unvalidated URL scheme |
| `core/image_gen.py` | 156 | B310 | Medium | `urllib.request.urlopen` — unvalidated URL scheme |
| `core/research_agent.py` | 198 | B310 | Medium | `urllib.request.urlopen` — unvalidated URL scheme |
| `core/server_home.py` | 241 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
| `core/server_home.py` | 265 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
| `core/server_home.py` | 298 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
| `core/server_home.py` | 302 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
| `core/server_home.py` | 306 | B601 | Medium | Paramiko `exec_command` — potential shell injection |
| `core/server_home.py` | 312 | B601 | Medium | Paramiko `exec_command` — potential shell injection |

---

## 🔍 Secret Scan

No secrets detected. 0 matches for patterns: `sk-*`, `ghp_*`, `AKIA*`, `-----BEGIN * PRIVATE KEY-----`.

---

## Delta vs 前日

`security/audit-2026-05-11` ブランチは存在するが、ローカルに前日 Markdown レポートがないため自動差分不可。次回実行時から差分表示が有効になります。

---

## Recommendations (優先度順)

1. **[P0] diskcache キャッシュディレクトリのパーミッション強化** — CVE-2025-69872 のパッチが未リリースのため、当面の回避策としてキャッシュディレクトリを `chmod 700`（プロセスオーナー専用）に制限。`diskcache.Cache(disk=diskcache.JSONDisk)` への切り替えを検討。

2. **[P0] paramiko の SHA-1 無効化** — CVE-2026-44405 のパッチが未リリースのため、`core/server_home.py` の SSH 接続設定で `preferred_pubkeys=('ecdsa-sha2-nistp256', 'ssh-ed25519')` を指定して SHA-1 ネゴシエーションを排除。

3. **[P1] cryptography ライブラリのアップグレード** — 現在 v41.0.7 は v48.0.0 より 7 メジャーバージョン古く、複数の CVE が修正済み。`pip install --upgrade cryptography` を実行しテストを通過させること。

4. **[P2] `core/conversation_search.py` の SQL クエリをパラメータ化** — B608 の 2 箇所 (line 306, 368) は f-string でテーブル名・列名を展開している。allowlist チェック済みであれば `# nosec B608` で明示抑制、そうでなければパラメータバインディングに移行。

5. **[P3] `urllib.request.urlopen` 呼び出しの URL スキーム検証強化** — B310 の 3 箇所は `https://` のみを許可するスキームチェックを呼び出し前に追加すること。

---

<details>
<summary>Raw Outputs</summary>

### pip-audit

```
Found 2 known vulnerabilities in 2 packages
Name      Version ID             Fix Versions
--------- ------- -------------- ------------
paramiko  3.5.1   CVE-2026-44405
diskcache 5.6.3   CVE-2025-69872
```

### pip list --outdated

```
Package            Version   Latest    Type
------------------ --------- --------- -----
argcomplete        3.1.4     3.6.3     wheel
blinker            1.7.0     1.9.0     wheel
certifi            2026.2.25 2026.4.22 wheel
charset-normalizer 3.4.6     3.4.7     wheel
conan              2.27.0    2.28.1    wheel
cryptography       41.0.7    48.0.0    wheel
dbus-python        1.3.2     1.4.0     sdist
httplib2           0.20.4    0.31.2    wheel
idna               3.11      3.14      wheel
launchpadlib       1.11.0    2.1.0     wheel
lazr.uri           1.0.6     1.0.8     wheel
oauthlib           3.2.2     3.3.1     wheel
packaging          24.0      26.2      wheel
patch-ng           1.18.1    1.19.1    wheel
pip                24.0      26.1.1    wheel
PyGObject          3.48.2    3.56.3    sdist
PyJWT              2.7.0     2.12.1    wheel
pyparsing          3.1.1     3.3.2     wheel
PyYAML             6.0.1     6.0.3     wheel
requests           2.33.1    2.34.0    wheel
setuptools         68.1.2    82.0.1    wheel
six                1.16.0    1.17.0    wheel
urllib3            2.6.3     2.7.0     wheel
wadllib            1.3.6     2.0.0     wheel
wheel              0.42.0    0.47.0    wheel
xmltodict          0.13.0    1.0.4     wheel
yq                 3.1.0     3.4.3     wheel
```

### bandit summary

```
Total lines of code: 54471
Total issues (by severity): High: 0, Medium: 11, Low: 365
```

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVjauT9xgoyD1qtMnVDUYm)_