### PR TITLE
[URGENT] 🚨 Security Audit 2026-05-14

### DIFF
--- a/logs/security/2026-05-14.md
+++ b/logs/security/2026-05-14.md
@@ -1,0 +1,173 @@
+# 🛡 ai-chan Daily Security Audit — 2026-05-14
+
+| Item | Value |
+|------|-------|
+| Date (UTC) | 2026-05-14 |
+| Commit | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| pip-audit | 2.10.0 |
+| bandit | 1.9.4 |
+| python | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---------|----------|------|--------|-----|
+| pip-audit | 0 | 1 | 1 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | 0 | 0 | 0 | 0 |
+| outdated (major) | — | — | — | 7 |
+
+> **pip-audit severity mapping**: CVE-2025-69872 (diskcache, arbitrary code execution) → HIGH; CVE-2026-44405 (paramiko, SHA-1 allowed) → MEDIUM
+
+---
+
+## 🚨 Critical / High Findings (pip-audit)
+
+### CVE-2025-69872 — `diskcache` 5.6.3 — **HIGH**
+
+- **GHSA**: GHSA-w8v5-vhqr-4h9v
+- **Fix versions**: None published yet
+- **Description**: DiskCache through 5.6.3 uses Python pickle for serialization by default. An attacker with write access to the cache directory can achieve arbitrary code execution when a victim application reads from the cache.
+- **Action**: Audit all `diskcache.Cache()` usages; consider switching to a JSON-backed cache or enabling trust policies until a patched release is available.
+
+---
+
+## ⚠ Outdated Dependencies (major version bumps only)
+
+| Package | Current | Latest |
+|---------|---------|--------|
+| cryptography | 41.0.7 | 48.0.0 |
+| launchpadlib | 1.11.0 | 2.1.0 |
+| packaging | 24.0 | 26.2 |
+| pip | 24.0 | 26.1.1 |
+| setuptools | 68.1.2 | 82.0.1 |
+| wadllib | 1.3.6 | 2.0.0 |
+| xmltodict | 0.13.0 | 1.0.4 |
+
+> `cryptography` is particularly notable — major versions often include breaking API changes and security fixes.
+
+---
+
+## 📋 Bandit Findings (Medium only — 11 issues, 0 High)
+
+| Severity | ID | Location | Issue |
+|----------|----|----------|-------|
+| Medium | B608 | `core/conversation_search.py:306` | SQL injection via f-string query construction (CWE-89) |
+| Medium | B608 | `core/conversation_search.py:368` | SQL injection via f-string query construction (CWE-89) |
+| Medium | B310 | `core/github_learner.py:180` | `urllib.request.urlopen` — unvalidated scheme (CWE-22) |
+| Medium | B310 | `core/image_gen.py:156` | `urllib.request.urlopen` — unvalidated scheme (CWE-22) |
+| Medium | B310 | `core/research_agent.py:198` | `urllib.request.urlopen` — unvalidated scheme (CWE-22) |
+| Medium | B601 | `core/server_home.py:241` | Paramiko `exec_command` — possible shell injection (CWE-78) |
+| Medium | B601 | `core/server_home.py:265` | Paramiko `exec_command` — possible shell injection (CWE-78) |
+| Medium | B601 | `core/server_home.py:298` | Paramiko `exec_command` — possible shell injection (CWE-78) |
+| Medium | B601 | `core/server_home.py:302` | Paramiko `exec_command` — possible shell injection (CWE-78) |
+| Medium | B601 | `core/server_home.py:306` | Paramiko `exec_command` — possible shell injection (CWE-78) |
+| Medium | B601 | `core/server_home.py:312` | Paramiko `exec_command` — possible shell injection (CWE-78) |
+
+> Low severity: 365 issues (not listed here — see Raw Outputs).
+
+---
+
+## 🔍 Secret Scan
+
+**No secrets detected.** (Patterns checked: `sk-*` API keys, `ghp_*` GitHub tokens, `AKIA*` AWS keys, PEM private key headers)
+
+---
+
+## Delta vs Previous Day
+
+No previous audit log found (`logs/security/2026-05-13.md` does not exist). This is the first recorded audit.
+
+---
+
+## Recommendations (priority order)
+
+1. **[HIGH] Mitigate diskcache pickle RCE (CVE-2025-69872)** — Review all `diskcache` usage in the codebase. Restrict cache directory permissions (0700) so only the service account can write. Pin the issue and monitor for an upstream fix or switch to `shelve`/SQLite-backed cache.
+
+2. **[HIGH] Address paramiko SHA-1 (CVE-2026-44405)** — paramiko 3.5.1 permits SHA-1 in RSA key negotiation. Disable SHA-1 explicitly via `server.set_allowed_macs()` or upgrade to a version with SHA-1 disabled by default once available.
+
+3. **[MEDIUM] Harden SQL query construction in `core/conversation_search.py`** — Lines 306 and 368 build queries with f-strings. Validate/allowlist all interpolated identifiers (table name, column names) against a fixed schema-derived whitelist before execution.
+
+4. **[MEDIUM] Audit Paramiko `exec_command` calls in `core/server_home.py`** — Ensure all commands passed to `exec_command` are hardcoded strings or strictly validated. Never interpolate user-supplied input into shell commands executed via SSH.
+
+5. **[LOW] Update `cryptography` (41.x → 48.x)** — The cryptography library had multiple CVEs across major versions. Upgrading is low risk (pure Python interface unchanged) and closes known vulnerabilities.
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip-audit CVE Details
+
+**CVE-2026-44405** (paramiko 3.5.1, GHSA-r374-rxx8-8654):
+> In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm.
+
+**CVE-2025-69872** (diskcache 5.6.3, GHSA-w8v5-vhqr-4h9v):
+> DiskCache (python-diskcache) through 5.6.3 uses Python pickle for serialization by default. An attacker with write access to the cache directory can achieve arbitrary code execution when a victim application reads from the cache.
+
+### Outdated Packages (full list)
+
+```
+Package              Current     Latest
+-------------------- ----------- -----------
+argcomplete          3.1.4       3.6.3
+blinker              1.7.0       1.9.0
+certifi              2026.2.25   2026.4.22
+charset-normalizer   3.4.6       3.4.7
+conan                2.27.0      2.28.1
+cryptography         41.0.7      48.0.0      [MAJOR]
+dbus-python          1.3.2       1.4.0
+httplib2             0.20.4      0.31.2
+idna                 3.11        3.15
+launchpadlib         1.11.0      2.1.0       [MAJOR]
+lazr.uri             1.0.6       1.0.8
+oauthlib             3.2.2       3.3.1
+packaging            24.0        26.2        [MAJOR]
+patch-ng             1.18.1      1.19.1
+pip                  24.0        26.1.1      [MAJOR]
+PyGObject            3.48.2      3.56.3
+PyJWT                2.7.0       2.12.1
+pyparsing            3.1.1       3.3.2
+PyYAML               6.0.1       6.0.3
+requests             2.33.1      2.34.1
+setuptools           68.1.2      82.0.1      [MAJOR]
+six                  1.16.0      1.17.0
+urllib3              2.6.3       2.7.0
+wadllib              1.3.6       2.0.0       [MAJOR]
+wheel                0.42.0      0.47.0
+xmltodict            0.13.0      1.0.4       [MAJOR]
+yq                   3.1.0       3.4.3
+```
+
+### Bandit (summary)
+
+```
+Code scanned:
+    Total lines of code: 54471
+    Total lines skipped (#nosec): 0
+    Total potential issues skipped due to specifically being disabled: 10
+
+Run metrics:
+    Total issues (by severity):
+        Low: 365
+        Medium: 11
+        High: 0
+    Total issues (by confidence):
+        Low: 1
+        Medium: 10
+        High: 365
+```
+
+</details>


### PR DESCRIPTION
# 🛡 ai-chan Daily Security Audit — 2026-05-14

| Item | Value |
|------|-------|
| Date (UTC) | 2026-05-14 |
| Commit | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
| pip-audit | 2.10.0 |
| bandit | 1.9.4 |

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---------|----------|------|--------|-----|
| pip-audit | 0 | 1 | 1 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| secrets | 0 | 0 | 0 | 0 |
| outdated (major) | — | — | — | 7 |

---

## 🚨 High Findings

### CVE-2025-69872 — `diskcache` 5.6.3 — **HIGH**
- **GHSA**: GHSA-w8v5-vhqr-4h9v
- **Fix versions**: None published yet
- **Description**: Pickle serialization by default allows arbitrary code execution if an attacker has write access to the cache directory.

### CVE-2026-44405 — `paramiko` 3.5.1 — **MEDIUM**
- **GHSA**: GHSA-r374-rxx8-8654
- **Description**: SHA-1 algorithm is permitted in RSA key negotiation.

---

## ⚠ Outdated (Major Bumps)

| Package | Current | Latest |
|---------|---------|--------|
| cryptography | 41.0.7 | 48.0.0 |
| launchpadlib | 1.11.0 | 2.1.0 |
| packaging | 24.0 | 26.2 |
| pip | 24.0 | 26.1.1 |
| setuptools | 68.1.2 | 82.0.1 |
| wadllib | 1.3.6 | 2.0.0 |
| xmltodict | 0.13.0 | 1.0.4 |

---

## 📋 Bandit — Medium Findings (11)

| ID | Location | Issue |
|----|----------|-------|
| B608 | `core/conversation_search.py:306` | SQL injection via f-string (CWE-89) |
| B608 | `core/conversation_search.py:368` | SQL injection via f-string (CWE-89) |
| B310 | `core/github_learner.py:180` | urlopen unvalidated scheme (CWE-22) |
| B310 | `core/image_gen.py:156` | urlopen unvalidated scheme (CWE-22) |
| B310 | `core/research_agent.py:198` | urlopen unvalidated scheme (CWE-22) |
| B601 | `core/server_home.py:241` | Paramiko exec_command shell injection (CWE-78) |
| B601 | `core/server_home.py:265` | Paramiko exec_command shell injection (CWE-78) |
| B601 | `core/server_home.py:298` | Paramiko exec_command shell injection (CWE-78) |
| B601 | `core/server_home.py:302` | Paramiko exec_command shell injection (CWE-78) |
| B601 | `core/server_home.py:306` | Paramiko exec_command shell injection (CWE-78) |
| B601 | `core/server_home.py:312` | Paramiko exec_command shell injection (CWE-78) |

---

## 🔍 Secret Scan

No secrets detected.

---

## Recommendations

1. **[HIGH]** Restrict `diskcache` cache directory permissions (chmod 0700) and monitor for upstream patch to CVE-2025-69872.
2. **[HIGH]** Disable SHA-1 in paramiko or upgrade once CVE-2026-44405 fix is published.
3. **[MEDIUM]** Validate/allowlist SQL identifiers in `core/conversation_search.py:306,368`.
4. **[MEDIUM]** Audit Paramiko `exec_command` calls in `core/server_home.py` — ensure no user input is interpolated.
5. **[LOW]** Upgrade `cryptography` from 41.x to 48.x to close known CVEs in intermediate versions.

---

Full report: `logs/security/2026-05-14.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhuJjfthzA3DdnWucVBnBJ)_