### PR TITLE
chore(security): Daily Audit 2026-05-21

### DIFF
--- a/logs/security/2026-05-21.md
+++ b/logs/security/2026-05-21.md
@@ -1,0 +1,175 @@
+# 🛡 Security Audit Report — 2026-05-21
+
+| Field | Value |
+|---|---|
+| **Date (UTC)** | 2026-05-21 |
+| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| **pip-audit** | 2.10.0 |
+| **bandit** | 1.9.4 |
+| **Python** | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| pip-audit (vulns) | 0 | 2 | 4 | 17 |
+| bandit | 0 | 0 | 11 | 365 |
+| Secret Scan | — | 0 hits | — | — |
+| Outdated (major↑) | — | — | 7 | 20 |
+
+> **Severity mapping for pip-audit**: paramiko CVE-2026-44405 and python-jose PYSEC-2025-185 rated HIGH (network-accessible / auth-bypass class); diskcache CVE-2025-69872 + joblib PYSEC-2024-277 rated MEDIUM; torch (11 issues) + transformers (8 issues) rated LOW (local-execution / ML-pipeline attack surface).
+
+---
+
+## 🚨 High Findings (pip-audit)
+
+| Package | Version | ID | Fix Version | Notes |
+|---|---|---|---|---|
+| `paramiko` | 3.5.1 | **CVE-2026-44405** | *(no fix released)* | SSH transport vulnerability; network-reachable |
+| `python-jose` | 3.5.0 | **PYSEC-2025-185** | *(no fix released)* | JWT library; potential token forgery / bypass |
+
+---
+
+## ⚠ Outdated Dependencies (major version updates only)
+
+| Package | Current | Latest |
+|---|---|---|
+| `cryptography` | 41.0.7 | **48.0.0** |
+| `launchpadlib` | 1.11.0 | **2.1.0** |
+| `packaging` | 24.0 | **26.2** |
+| `pip` | 24.0 | **26.1.1** |
+| `setuptools` | 68.1.2 | **82.0.1** |
+| `wadllib` | 1.3.6 | **2.0.0** |
+| `xmltodict` | 0.13.0 | **1.0.4** |
+
+> ⚠ `cryptography` is 7 major versions behind (41 → 48) and directly relates to TLS/key security. Prioritize upgrading.
+
+---
+
+## 📋 Bandit Findings (Medium severity)
+
+| Severity | File | Line | Issue ID | Description |
+|---|---|---|---|---|
+| MEDIUM | `core/conversation_search.py` | 306 | B608 | SQL injection via f-string query construction (CWE-89) |
+| MEDIUM | `core/conversation_search.py` | 368 | B608 | SQL injection via f-string query construction (CWE-89) |
+| MEDIUM | `core/github_learner.py` | 180 | B310 | `urllib.request.urlopen` — permits `file:/` scheme (CWE-22) |
+| MEDIUM | `core/image_gen.py` | 156 | B310 | `urllib.request.urlopen` — permits `file:/` scheme (CWE-22) |
+| MEDIUM | `core/research_agent.py` | 198 | B310 | `urllib.request.urlopen` — permits `file:/` scheme (CWE-22) |
+| MEDIUM | `core/server_home.py` | 241 | B601 | Paramiko `exec_command` — possible shell injection (CWE-78) |
+| MEDIUM | `core/server_home.py` | 265 | B601 | Paramiko `exec_command` — possible shell injection (CWE-78) |
+| MEDIUM | `core/server_home.py` | 298 | B601 | Paramiko `exec_command` — possible shell injection (CWE-78) |
+| MEDIUM | `core/server_home.py` | 302 | B601 | Paramiko `exec_command` — possible shell injection (CWE-78) |
+| MEDIUM | `core/server_home.py` | 306 | B601 | Paramiko `exec_command` — possible shell injection (CWE-78) |
+| MEDIUM | `core/server_home.py` | 312 | B601 | Paramiko `exec_command` — possible shell injection (CWE-78) |
+
+**Total (by severity):** High: 0, Medium: 11, Low: 365 (Low suppressed in this report)
+
+---
+
+## 🔍 Secret Scan
+
+No secrets detected. Pattern coverage: `sk-*`, `ghp_*`, `AKIA*`, `BEGIN PRIVATE KEY` variants.
+
+---
+
+## Delta vs 前日 (2026-05-20)
+
+前日レポート (`logs/security/2026-05-20.md`) が存在しないため差分なし — 本日が初回監査記録です。
+
+---
+
+## Recommendations (優先度順)
+
+1. **[HIGH] paramiko をアップグレードまたは回避策を適用** — CVE-2026-44405 の fix がまだリリースされていないが、影響を受けるコード (`core/server_home.py`) の SSH コマンド実行を最小化し、入力をホワイトリスト化すること。
+2. **[HIGH] python-jose を交換** — PYSEC-2025-185 の fix なし。メンテナンス停滞気味のライブラリ。`PyJWT` (既にシステムにあり) への移行を検討。
+3. **[HIGH] cryptography を 41 → 48 へアップグレード** — 7 メジャーバージョン差。TLS / 鍵操作の基幹ライブラリであり最優先。`pip install --upgrade cryptography` 後に結合テスト実施。
+4. **[MEDIUM] B608 SQL f-string を修正** — `core/conversation_search.py:306,368` で列名・テーブル名を f-string で展開している。SQLite の `PRAGMA table_info` で列名を検証し許可リスト方式に変更。
+5. **[MEDIUM] B601 Paramiko コマンドをリテラル化** — `core/server_home.py` の `exec_command` 呼び出しはすべてリテラル文字列か、コマンドを定数リストに限定して shlex で結合。外部入力を渡している箇所は即時修正。
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 23 known vulnerabilities in 6 packages
+Name         Version ID             Fix Versions
+------------ ------- -------------- ------------
+paramiko     3.5.1   CVE-2026-44405
+python-jose  3.5.0   PYSEC-2025-185
+transformers 5.9.0   PYSEC-2025-211
+transformers 5.9.0   PYSEC-2025-212
+transformers 5.9.0   PYSEC-2025-215
+transformers 5.9.0   PYSEC-2025-213
+transformers 5.9.0   PYSEC-2025-214
+transformers 5.9.0   PYSEC-2025-217
+transformers 5.9.0   PYSEC-2025-218
+transformers 5.9.0   PYSEC-2025-216
+diskcache    5.6.3   CVE-2025-69872
+joblib       1.5.3   PYSEC-2024-277
+torch        2.12.0  PYSEC-2025-210
+torch        2.12.0  PYSEC-2025-194
+torch        2.12.0  PYSEC-2025-196
+torch        2.12.0  PYSEC-2025-195
+torch        2.12.0  PYSEC-2025-193
+torch        2.12.0  PYSEC-2025-192
+torch        2.12.0  PYSEC-2026-139
+torch        2.12.0  PYSEC-2025-191
+torch        2.12.0  PYSEC-2025-197
+torch        2.12.0  PYSEC-2025-189
+torch        2.12.0  PYSEC-2025-190
+```
+
+### bandit (text)
+
+```
+Run started: 2026-05-21 00:09:33.456909+00:00
+
+Total issues (by severity):
+    Undefined: 0 / Low: 365 / Medium: 11 / High: 0
+Total issues (by confidence):
+    Undefined: 0 / Low: 1 / Medium: 10 / High: 365
+Total lines of code: 54471
+Total lines skipped (#nosec): 0
+Nosec suppressed: 10
+```
+
+### pip list --outdated
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.5.20 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.28.1    wheel
+cryptography       41.0.7    48.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.15      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.1    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.12.1    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+requests           2.33.1    2.34.2    wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+</details>


### PR DESCRIPTION
# 🛡 Security Audit — 2026-05-21

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---|---|---|---|---|
| pip-audit (vulns) | 0 | 2 | 4 | 17 |
| bandit | 0 | 0 | 11 | 365 |
| Secret Scan | — | 0 hits | — | — |
| Outdated (major↑) | — | — | 7 | 20 |

- **Commit scanned:** `40bb06efeb35b72f5823fd6a27c9db2ad49f896c`
- **pip-audit:** 2.10.0 | **bandit:** 1.9.4 | **Python:** 3.11.15

---

## 🚨 High Findings (pip-audit)

| Package | Version | ID | Fix Version |
|---|---|---|---|
| `paramiko` | 3.5.1 | CVE-2026-44405 | *(no fix released)* |
| `python-jose` | 3.5.0 | PYSEC-2025-185 | *(no fix released)* |

## ⚠ Outdated (major version bumps)

`cryptography` 41→48, `launchpadlib` 1→2, `packaging` 24→26, `pip` 24→26, `setuptools` 68→82, `wadllib` 1→2, `xmltodict` 0→1

## 📋 Bandit Medium Findings

- B608 SQL f-string: `core/conversation_search.py:306,368`
- B310 urlopen file-scheme: `core/github_learner.py:180`, `core/image_gen.py:156`, `core/research_agent.py:198`
- B601 Paramiko exec_command: `core/server_home.py:241,265,298,302,306,312`

## 🔍 Secrets

None detected.

## Recommendations (優先度順)

1. **[HIGH]** `paramiko` CVE-2026-44405 — SSH コマンド入力をホワイトリスト化
2. **[HIGH]** `python-jose` → `PyJWT` へ移行 (既にシステムに存在)
3. **[HIGH]** `cryptography` 41 → 48 アップグレード
4. **[MEDIUM]** B608: `conversation_search.py` の SQL f-string を許可リスト方式に変更
5. **[MEDIUM]** B601: `server_home.py` の Paramiko コマンドをリテラル定数に限定

Full report: `logs/security/2026-05-21.md`
Issue: https://github.com/FIshota/AI/issues/55

---
_Generated by [Claude Code](https://claude.ai/code/session_01377nSemCgQh7cqavL26BtX)_