### PR TITLE
[URGENT] 🚨 Security Audit 2026-05-24

### DIFF
--- a/logs/security/2026-05-24.md
+++ b/logs/security/2026-05-24.md
@@ -1,0 +1,177 @@
+# 🛡 ai-chan Security Audit — 2026-05-24
+
+| Field | Value |
+|---|---|
+| **Date (UTC)** | 2026-05-24 |
+| **Commit SHA** | 40bb06e |
+| **pip-audit** | 2.10.0 |
+| **bandit** | 1.9.4 |
+| **Python** | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| pip-audit (CVEs) | 0 | 2 | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| Secrets | — | — | — | 0 |
+| Outdated (major) | — | — | — | 7 |
+
+**Total actionable findings: 2 CVEs (HIGH) + 11 bandit MEDIUM**
+
+---
+
+## 🚨 Critical / High Findings (CVEs)
+
+### CVE-2026-44405 — paramiko 3.5.1
+- **GHSA:** GHSA-r374-rxx8-8654
+- **Severity:** HIGH (weak cryptography)
+- **Description:** Paramiko through 4.0.0 (before commit a448945) permits the SHA-1 algorithm in `rsakey.py`, enabling downgrade attacks against RSA host-key verification.
+- **Fix Version:** No official release fix yet — patch via commit `a448945` or pin to a post-fix build.
+- **Impact:** SSH connections using RSA keys may be vulnerable to signature forgery via SHA-1 collision.
+
+### CVE-2025-69872 — diskcache 5.6.3
+- **GHSA:** GHSA-w8v5-vhqr-4h9v
+- **Severity:** HIGH (insecure deserialization / potential RCE)
+- **Description:** DiskCache through 5.6.3 uses Python `pickle` for serialization by default. An attacker with write access to the cache backend can achieve arbitrary code execution.
+- **Fix Version:** No official release fix yet — mitigate by disabling pickle or restricting cache storage permissions.
+- **Impact:** If the cache storage path is attacker-writable, RCE is possible on cache reads.
+
+---
+
+## ⚠ Outdated Dependencies (major version bumps)
+
+| Package | Current | Latest | Notes |
+|---|---|---|---|
+| cryptography | 41.0.7 | **48.0.0** | 7 major versions behind — security-critical |
+| setuptools | 68.1.2 | 82.0.1 | Build toolchain |
+| packaging | 24.0 | 26.2 | Build support |
+| pip | 24.0 | 26.1.1 | Package manager |
+| launchpadlib | 1.11.0 | 2.1.0 | Ubuntu PPA integration |
+| wadllib | 1.3.6 | 2.0.0 | WADL client |
+| xmltodict | 0.13.0 | 1.0.4 | XML parsing |
+
+> Note: `cryptography` installed in the audit environment is 48.0.0 (latest) but `requirements.txt` pins an older version.
+
+---
+
+## 📋 Bandit Findings (High/Medium only)
+
+| Severity | Test ID | File | Line | Issue |
+|---|---|---|---|---|
+| MEDIUM | B608 | `core/conversation_search.py` | 306 | SQL injection vector — f-string in SELECT query |
+| MEDIUM | B608 | `core/conversation_search.py` | 368 | SQL injection vector — f-string in SELECT query |
+| MEDIUM | B310 | `core/github_learner.py` | 180 | `urllib.request.urlopen` — unapproved scheme risk |
+| MEDIUM | B310 | `core/image_gen.py` | 156 | `urllib.request.urlopen` — unapproved scheme risk |
+| MEDIUM | B310 | `core/research_agent.py` | 198 | `urllib.request.urlopen` — unapproved scheme risk |
+| MEDIUM | B601 | `core/server_home.py` | 241 | Paramiko `exec_command` — potential shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 265 | Paramiko `exec_command` — potential shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 298 | Paramiko `exec_command` — potential shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 302 | Paramiko `exec_command` — potential shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 306 | Paramiko `exec_command` — potential shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 312 | Paramiko `exec_command` — potential shell injection |
+
+> 10 findings suppressed via `#nosec` in source (B608×4 in memory files, B507×1 in server_home).
+
+---
+
+## 🔍 Secret Scan
+
+No secrets detected. Patterns scanned: Anthropic `sk-*`, GitHub PAT `ghp_*`, AWS AKIA, PEM private key headers.
+
+---
+
+## Delta vs 前日
+
+前日のレポート (`logs/security/2026-05-23.md`) が存在しないため、差分なし（初回または欠損）。
+
+---
+
+## Recommendations (優先度順)
+
+1. **[P1 — 即時] paramiko CVE-2026-44405 対応:** `paramiko` を `a448945` 以降のコミットを含むバージョンに更新するか、公式修正リリースを待ちピン留め。SSH 接続で RSA キーを使用している箇所 (`core/server_home.py`) が直接影響範囲。
+
+2. **[P1 — 即時] diskcache CVE-2025-69872 対応:** キャッシュストレージディレクトリへの書き込み権限を最小化。公式修正リリースまでは `DiskCache(…, disk=diskcache.JSONDisk)` 等 pickle 以外のシリアライザへ移行を検討。
+
+3. **[P2 — 今週中] cryptography を最新へ更新:** `requirements.txt` の `cryptography` が 41.x 系 — 48.x に比べ多数の脆弱性修正が含まれる。特に `paramiko` も間接的に依存するため優先度高。
+
+4. **[P3 — 今スプリント] B608 SQL インジェクション対策:** `core/conversation_search.py:306,368` の f-string SQL を `sqlite3` パラメータバインドに書き換え。現状は列名・テーブル名が変数 — 入力元が内部ならリスクは限定的だが修正推奨。
+
+5. **[P3 — 今スプリント] B601 Paramiko `exec_command` 入力検証:** `core/server_home.py` の `cmd` 変数が外部入力を含む場合はホワイトリスト検証を追加。静的文字列のみの呼び出し (`"uptime -p"` 等) は低リスクだが、`cmd` 変数渡し箇所 (265行) は要確認。
+
+---
+
+<details>
+<summary>Raw outputs</summary>
+
+### pip-audit
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip list --outdated
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.5.20 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.28.1    wheel
+cryptography       41.0.7    48.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.16      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.1    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.13.0    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+requests           2.33.1    2.34.2    wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+### bandit
+
+```
+Run started: 2026-05-24 00:14:02.435362+00:00
+
+Code scanned:
+    Total lines of code: 54471
+    Total lines skipped (#nosec): 0
+    Total potential issues skipped due to specifically being disabled: 10
+
+Run metrics:
+    Total issues (by severity):
+        Undefined: 0
+        Low: 365
+        Medium: 11
+        High: 0
+    Total issues (by confidence):
+        Undefined: 0
+        Low: 1
+        Medium: 10
+        High: 365
+Files skipped (0)
+```
+
+</details>


### PR DESCRIPTION
# 🛡 ai-chan Security Audit — 2026-05-24

| Field | Value |
|---|---|
| **Date (UTC)** | 2026-05-24 |
| **Commit SHA** | 40bb06e |
| **pip-audit** | 2.10.0 |
| **bandit** | 1.9.4 |
| **Python** | 3.11.15 |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---|---|---|---|---|
| pip-audit (CVEs) | 0 | **2** | 0 | 0 |
| bandit | 0 | 0 | **11** | 365 |
| Secrets | — | — | — | 0 |
| Outdated (major) | — | — | — | 7 |

**Total actionable findings: 2 CVEs (HIGH) + 11 bandit MEDIUM**

---

## 🚨 Critical / High Findings (CVEs)

### CVE-2026-44405 — paramiko 3.5.1
- **GHSA:** GHSA-r374-rxx8-8654
- **Severity:** HIGH (weak cryptography)
- **Description:** Paramiko through 4.0.0 (before commit a448945) permits the SHA-1 algorithm in `rsakey.py`, enabling downgrade attacks against RSA host-key verification.
- **Fix Version:** No official release fix yet — patch via commit `a448945` or pin to a post-fix build.
- **Impact:** SSH connections using RSA keys may be vulnerable to signature forgery via SHA-1 collision.

### CVE-2025-69872 — diskcache 5.6.3
- **GHSA:** GHSA-w8v5-vhqr-4h9v
- **Severity:** HIGH (insecure deserialization / potential RCE)
- **Description:** DiskCache through 5.6.3 uses Python `pickle` for serialization by default. An attacker with write access to the cache backend can achieve arbitrary code execution.
- **Fix Version:** No official release fix yet — mitigate by disabling pickle or restricting cache storage permissions.
- **Impact:** If the cache storage path is attacker-writable, RCE is possible on cache reads.

---

## ⚠ Outdated Dependencies (major version bumps)

| Package | Current | Latest | Notes |
|---|---|---|---|
| cryptography | 41.0.7 | **48.0.0** | 7 major versions behind — security-critical |
| setuptools | 68.1.2 | 82.0.1 | Build toolchain |
| packaging | 24.0 | 26.2 | Build support |
| pip | 24.0 | 26.1.1 | Package manager |
| launchpadlib | 1.11.0 | 2.1.0 | Ubuntu PPA integration |
| wadllib | 1.3.6 | 2.0.0 | WADL client |
| xmltodict | 0.13.0 | 1.0.4 | XML parsing |

---

## 📋 Bandit Findings (High/Medium only)

| Severity | Test ID | File | Line | Issue |
|---|---|---|---|---|
| MEDIUM | B608 | `core/conversation_search.py` | 306 | SQL injection vector — f-string in SELECT query |
| MEDIUM | B608 | `core/conversation_search.py` | 368 | SQL injection vector — f-string in SELECT query |
| MEDIUM | B310 | `core/github_learner.py` | 180 | `urllib.request.urlopen` — unapproved scheme risk |
| MEDIUM | B310 | `core/image_gen.py` | 156 | `urllib.request.urlopen` — unapproved scheme risk |
| MEDIUM | B310 | `core/research_agent.py` | 198 | `urllib.request.urlopen` — unapproved scheme risk |
| MEDIUM | B601 | `core/server_home.py` | 241 | Paramiko `exec_command` — potential shell injection |
| MEDIUM | B601 | `core/server_home.py` | 265 | Paramiko `exec_command` — potential shell injection |
| MEDIUM | B601 | `core/server_home.py` | 298 | Paramiko `exec_command` — potential shell injection |
| MEDIUM | B601 | `core/server_home.py` | 302 | Paramiko `exec_command` — potential shell injection |
| MEDIUM | B601 | `core/server_home.py` | 306 | Paramiko `exec_command` — potential shell injection |
| MEDIUM | B601 | `core/server_home.py` | 312 | Paramiko `exec_command` — potential shell injection |

> 10 findings suppressed via `#nosec` in source.

---

## 🔍 Secret Scan

No secrets detected. Patterns scanned: Anthropic `sk-*`, GitHub PAT `ghp_*`, AWS AKIA, PEM private key headers.

---

## Delta vs 前日

前日のレポート (`logs/security/2026-05-23.md`) が存在しないため、差分なし（初回または欠損）。

---

## Recommendations (優先度順)

1. **[P1 — 即時] paramiko CVE-2026-44405 対応:** `paramiko` を `a448945` 以降のコミットを含むバージョンに更新するか、公式修正リリースを待ちピン留め。SSH 接続で RSA キーを使用している箇所 (`core/server_home.py`) が直接影響範囲。

2. **[P1 — 即時] diskcache CVE-2025-69872 対応:** キャッシュストレージディレクトリへの書き込み権限を最小化。公式修正リリースまでは `DiskCache(…, disk=diskcache.JSONDisk)` 等 pickle 以外のシリアライザへ移行を検討。

3. **[P2 — 今週中] cryptography を最新へ更新:** `requirements.txt` の `cryptography` が 41.x 系 — 48.x に比べ多数の脆弱性修正が含まれる。

4. **[P3 — 今スプリント] B608 SQL インジェクション対策:** `core/conversation_search.py:306,368` の f-string SQL を `sqlite3` パラメータバインドに書き換え。

5. **[P3 — 今スプリント] B601 Paramiko `exec_command` 入力検証:** `core/server_home.py` の `cmd` 変数渡し箇所 (265行) に外部入力が到達しないか確認。

---

<details>
<summary>Raw outputs</summary>

### pip-audit

```
Found 2 known vulnerabilities in 2 packages
Name      Version ID             Fix Versions
--------- ------- -------------- ------------
paramiko  3.5.1   CVE-2026-44405
diskcache 5.6.3   CVE-2025-69872
```

### bandit summary

```
Total lines of code: 54471
Total issues: High=0  Medium=11  Low=365
```

### pip list --outdated (抜粋)

```
cryptography  41.0.7  → 48.0.0
launchpadlib  1.11.0  → 2.1.0
packaging     24.0    → 26.2
pip           24.0    → 26.1.1
setuptools    68.1.2  → 82.0.1
wadllib       1.3.6   → 2.0.0
xmltodict     0.13.0  → 1.0.4
```

</details>

---

*Generated by ai-chan security bot — automated audit*

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8ENMhkK4Gddxf4o8H3k3A)_