### PR TITLE
[URGENT] 🚨 Security Audit 2026-05-26

### DIFF
--- a/logs/security/2026-05-26.md
+++ b/logs/security/2026-05-26.md
@@ -1,0 +1,214 @@
+# 🛡 ai-chan Security Audit — 2026-05-26
+
+| Item | Value |
+|------|-------|
+| **Date (UTC)** | 2026-05-26 |
+| **Commit** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| **pip-audit** | 2.10.0 |
+| **bandit** | 1.9.4 |
+| **Python** | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---------|----------|------|--------|-----|
+| pip-audit (CVEs) | 0 | 2 | 0 | 0 |
+| bandit (SAST) | 0 | 0 | 11 | 365 |
+| Secret Scan | — | 0 hits | — | — |
+| Outdated (major) | — | — | 7 pkgs | 20 pkgs |
+
+**Overall status: ⚠️ ACTION REQUIRED — 2 HIGH CVEs (no fix versions available yet)**
+
+---
+
+## 🚨 Critical / High Findings
+
+### CVE-2026-44405 — paramiko 3.5.1
+| Field | Value |
+|-------|-------|
+| **Package** | paramiko 3.5.1 |
+| **GHSA** | GHSA-r374-rxx8-8654 |
+| **Fix Version** | ⛔ None available (affects through 4.0.0 before commit a448945) |
+| **Severity** | HIGH |
+| **Description** | `rsakey.py` allows the SHA-1 algorithm for RSA key operations. SHA-1 is cryptographically broken; this weakens host key verification and SSH authentication signatures. |
+| **Mitigation** | `requirements.txt` pins `paramiko>=3.5.0,<4.0` pending API diff review. Monitor upstream for the patch commit `a448945`. Consider disabling SHA-1 key exchange in SSH server configuration as a compensating control. |
+
+---
+
+### CVE-2025-69872 — diskcache 5.6.3
+| Field | Value |
+|-------|-------|
+| **Package** | diskcache 5.6.3 |
+| **GHSA** | GHSA-w8v5-vhqr-4h9v |
+| **Fix Version** | ⛔ None available |
+| **Severity** | HIGH |
+| **Description** | DiskCache uses Python `pickle` for serialization by default. An attacker with write access to the cache directory can achieve arbitrary code execution when a victim application loads the cache. |
+| **Mitigation** | `_secure_cache_dir()` restricts cache directory permissions (noted in `requirements.txt` as mitigated). However, no upstream fix exists. Ensure cache directory permissions are enforced on all deployment targets and validate that `_secure_cache_dir()` is called before any cache read. |
+
+---
+
+## ⚠️ Outdated Dependencies (Major Updates Only)
+
+| Package | Current | Latest | Notes |
+|---------|---------|--------|-------|
+| cryptography | 41.0.7 | 48.0.0 | **Security-critical lib** — `requirements.txt` pins `>=46.0.7`; installed version is stale (system pkg). Align installed with pinned. |
+| setuptools | 68.1.2 | 82.0.1 | Previously deferred; now 14 major versions behind |
+| packaging | 24.0 | 26.2 | 2 major versions behind |
+| pip | 24.0 | 26.1.1 | System-installed pip, update via OS packaging |
+| xmltodict | 0.13.0 | 1.0.4 | Major API changes possible |
+| launchpadlib | 1.11.0 | 2.1.0 | System package, update via OS |
+| wadllib | 1.3.6 | 2.0.0 | System package, update via OS |
+
+> ⚠️ **Note on `cryptography`**: The installed version is 41.0.7 (system package), while `requirements.txt` correctly pins `>=46.0.7`. This mismatch suggests the system Python's cryptography package is not being updated by `pip install -r requirements.txt`. Verify the active virtualenv or system path.
+
+---
+
+## 📋 Bandit Findings (High/Medium)
+
+> 0 HIGH findings. 11 MEDIUM findings below.
+
+### B608 — Possible SQL Injection (Medium/Medium)
+
+| File | Line | Issue |
+|------|------|-------|
+| `core/conversation_search.py` | 306 | f-string interpolation in `SELECT` statement (column/table names from config; confidence: Medium) |
+| `core/conversation_search.py` | 368 | f-string in full-text search query with `{limit * 4}`, `{join}`, `{where_sql}` (confidence: Low) |
+
+**Assessment**: Column/table names appear to be from internal config, not direct user input. Low exploitability, but validate that none of these interpolated values can be influenced by external input.
+
+### B310 — urllib.request.urlopen (Medium/High)
+
+| File | Line | Issue |
+|------|------|-------|
+| `core/github_learner.py` | 180 | `urlopen(req, timeout=timeout)` — `# noqa: S310` present |
+| `core/image_gen.py` | 156 | `urlopen(req, timeout=60)` — `# noqa: S310` present |
+| `core/research_agent.py` | 198 | `urlopen(req, timeout=5)` — `# noqa: S310` present |
+
+**Assessment**: All three have `# noqa: S310` suppression comments, indicating intentional use. Verify that URL inputs are validated against allowed schemes (`https://` only) before passing to `urlopen`.
+
+### B601 — Paramiko exec_command (Medium/Medium)
+
+| File | Line | Issue |
+|------|------|-------|
+| `core/server_home.py` | 241 | `exec_command("echo ok", timeout=5)` — hardcoded, no injection risk |
+| `core/server_home.py` | 265 | `exec_command(cmd, timeout=30)` — `cmd` variable; validate sanitization of input |
+| `core/server_home.py` | 298 | `exec_command("uptime -p", timeout=5)` — hardcoded, no injection risk |
+| `core/server_home.py` | 302 | `exec_command("df -h / | tail -1", timeout=5)` — hardcoded, no injection risk |
+| `core/server_home.py` | 306 | `exec_command("free -h | ...", timeout=5)` — hardcoded, no injection risk |
+| `core/server_home.py` | 312 | `exec_command("docker ps --format ...", timeout=5)` — hardcoded, no injection risk |
+
+**Assessment**: Line 265 (`cmd` variable) requires the most attention. Confirm that `cmd` is constructed from an allowlist, not raw user input.
+
+---
+
+## 🔍 Secret Scan
+
+**✅ No secrets detected** — 0 matches for API keys, GitHub tokens, AWS access keys, or private key headers in `*.py`, `*.json`, `*.yaml`, `*.yml` files.
+
+---
+
+## Delta vs Previous Day
+
+**No previous report found** (`logs/security/2026-05-25.md` does not exist). This is the first audit entry.
+
+---
+
+## Recommendations (Priority Order)
+
+1. **[P1] Monitor paramiko upstream for CVE-2026-44405 patch** — Check for commit `a448945` and update the `requirements.txt` upper bound `<4.0` constraint as soon as a patched 3.x or 4.x release is tagged. Subscribe to `GHSA-r374-rxx8-8654` notifications.
+
+2. **[P1] Verify `_secure_cache_dir()` enforcement for CVE-2025-69872** — Audit every call site that instantiates a `diskcache.Cache` and confirm `_secure_cache_dir()` is always invoked before any `get()` or `set()`. Add an integration test that validates the directory mode is `0o700`. Monitor for an upstream diskcache fix.
+
+3. **[P2] Align installed `cryptography` with pinned version** — The installed cryptography (41.0.7) is 5 major versions behind the `requirements.txt` pin (46.0.7). Run in a clean virtualenv or check if system Python is being used instead of the project venv, as the older system package may contain unfixed CVEs.
+
+4. **[P2] Audit `core/server_home.py:265` paramiko `cmd` variable** — Confirm `cmd` is assembled from a strict allowlist of shell commands. If user-supplied values flow into it, use `shlex.quote()` or switch to a structured paramiko channel API instead of `exec_command`.
+
+5. **[P3] Plan major dependency upgrades** — `setuptools` (68→82), `packaging` (24→26), `xmltodict` (0.13→1.0) are significantly behind. Schedule review in the next sprint; `cryptography` upgrade to 48.x should be bundled with the security fix above.
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip-audit (JSON)
+
+```json
+[
+  {
+    "pkg": "paramiko",
+    "version": "3.5.1",
+    "id": "CVE-2026-44405",
+    "fix_versions": [],
+    "aliases": ["GHSA-r374-rxx8-8654"],
+    "description": "In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm."
+  },
+  {
+    "pkg": "diskcache",
+    "version": "5.6.3",
+    "id": "CVE-2025-69872",
+    "fix_versions": [],
+    "aliases": ["GHSA-w8v5-vhqr-4h9v"],
+    "description": "DiskCache (python-diskcache) through 5.6.3 uses Python pickle for serialization by default. An attacker with write access to the cache directory can achieve arbitrary code execution when a victim application loads the cache."
+  }
+]
+```
+
+### bandit summary
+
+```
+Run started: 2026-05-26 00:04:47 UTC
+Total lines of code: 54471
+Total lines skipped (#nosec): 0
+Skipped tests (nosec BXXX): 10
+
+Total issues by severity:
+  UNDEFINED: 0 | LOW: 365 | MEDIUM: 11 | HIGH: 0
+Total issues by confidence:
+  UNDEFINED: 0 | LOW: 1 | MEDIUM: 10 | HIGH: 365
+```
+
+### pip outdated (all 27 packages)
+
+```
+argcomplete: 3.1.4 -> 3.6.3
+blinker: 1.7.0 -> 1.9.0
+certifi: 2026.2.25 -> 2026.5.20
+charset-normalizer: 3.4.6 -> 3.4.7
+conan: 2.27.0 -> 2.28.1
+cryptography: 41.0.7 -> 48.0.0  *** MAJOR ***
+dbus-python: 1.3.2 -> 1.4.0
+httplib2: 0.20.4 -> 0.31.2
+idna: 3.11 -> 3.16
+launchpadlib: 1.11.0 -> 2.1.0   *** MAJOR ***
+lazr.uri: 1.0.6 -> 1.0.8
+oauthlib: 3.2.2 -> 3.3.1
+packaging: 24.0 -> 26.2          *** MAJOR ***
+patch-ng: 1.18.1 -> 1.19.1
+pip: 24.0 -> 26.1.1              *** MAJOR ***
+PyGObject: 3.48.2 -> 3.56.3
+PyJWT: 2.7.0 -> 2.13.0
+pyparsing: 3.1.1 -> 3.3.2
+PyYAML: 6.0.1 -> 6.0.3
+requests: 2.33.1 -> 2.34.2
+setuptools: 68.1.2 -> 82.0.1    *** MAJOR ***
+six: 1.16.0 -> 1.17.0
+urllib3: 2.6.3 -> 2.7.0
+wadllib: 1.3.6 -> 2.0.0         *** MAJOR ***
+wheel: 0.42.0 -> 0.47.0
+xmltodict: 0.13.0 -> 1.0.4      *** MAJOR ***
+yq: 3.1.0 -> 3.4.3
+```
+
+</details>


### PR DESCRIPTION
# 🛡 ai-chan Daily Security Audit — 2026-05-26

**Status: ⚠️ ACTION REQUIRED — 2 HIGH CVEs with no upstream fix**

| Item | Value |
|------|-------|
| **Date (UTC)** | 2026-05-26 |
| **Commit** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
| **pip-audit** | 2.10.0 |
| **bandit** | 1.9.4 |
| **Issue** | https://github.com/FIshota/AI/issues/65 |

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---------|----------|------|--------|-----|
| pip-audit (CVEs) | 0 | 2 | 0 | 0 |
| bandit (SAST) | 0 | 0 | 11 | 365 |
| Secret Scan | — | 0 hits | — | — |
| Outdated (major) | — | — | 7 pkgs | 20 pkgs |

## 🚨 HIGH CVEs (No fix available)

### CVE-2026-44405 — paramiko 3.5.1
- **GHSA**: GHSA-r374-rxx8-8654
- **Fix**: ⛔ None (affects through 4.0.0 before commit a448945)
- SHA-1 algorithm allowed in RSA key operations — weakens SSH authentication signatures
- **Action**: Monitor upstream; enforce SHA-2 only in SSH server config as compensating control

### CVE-2025-69872 — diskcache 5.6.3
- **GHSA**: GHSA-w8v5-vhqr-4h9v
- **Fix**: ⛔ None
- Pickle deserialization enables arbitrary code execution for attackers with cache directory write access
- **Action**: Verify `_secure_cache_dir()` enforced at all call sites; add integration test for mode=0o700

## ⚠️ Major Dependency Updates Pending

| Package | Current | Latest | Priority |
|---------|---------|--------|----------|
| cryptography (installed vs pinned mismatch) | 41.0.7 installed / 46.0.7 pinned | 48.0.0 | High |
| setuptools | 68.1.2 | 82.0.1 | Medium |
| packaging | 24.0 | 26.2 | Low |
| xmltodict | 0.13.0 | 1.0.4 | Low |

## 📋 Bandit Findings Requiring Review

| File | Line | Issue | Severity |
|------|------|-------|----------|
| `core/conversation_search.py` | 306 | B608 SQL injection | Medium |
| `core/conversation_search.py` | 368 | B608 SQL injection | Medium |
| `core/server_home.py` | 265 | B601 paramiko exec_command — variable `cmd` | Medium |

## 🔍 Secrets: ✅ None detected

## Recommendations

1. **[P1]** Watch for paramiko patch commit `a448945` (CVE-2026-44405)
2. **[P1]** Audit all diskcache call sites — confirm `_secure_cache_dir()` always runs before cache reads
3. **[P2]** Fix cryptography version mismatch: installed 41.0.7 vs pinned ≥46.0.7 — likely stale system package
4. **[P2]** Review `server_home.py:265` — confirm `cmd` variable comes from an allowlist
5. **[P3]** Schedule major dependency upgrade sprint (setuptools 68→82, packaging 24→26, xmltodict 0.13→1.0)

---
Full report & raw outputs: `logs/security/2026-05-26.md`

*Generated by ai-chan security bot — 2026-05-26T00:04 UTC*

---
_Generated by [Claude Code](https://claude.ai/code/session_01A17acaGKsWRM2iUPDYMKxh)_