### PR TITLE
[URGENT] 🚨 Security Audit 2026-05-31

### DIFF
--- a/logs/security/2026-05-31.md
+++ b/logs/security/2026-05-31.md
@@ -1,0 +1,211 @@
+# 🛡 Daily Security Audit — 2026-05-31
+
+| Field | Value |
+|---|---|
+| Date | 2026-05-31 (UTC) |
+| Commit SHA | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| pip-audit | 2.10.0 |
+| bandit | 1.9.4 |
+| Python | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| pip-audit (CVEs) | 0 | 2 ⚠️ | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| Secret Scan | — | — | — | 0 |
+| Outdated (major) | — | — | — | 7 |
+
+> pip-audit の HIGH 2 件はいずれも **修正バージョン未公開** (no fix available)。
+
+---
+
+## 🚨 Critical / High Findings
+
+### CVE Vulnerabilities (pip-audit)
+
+| Package | Current | CVE ID | Fix Version | Notes |
+|---|---|---|---|---|
+| `paramiko` | 3.5.1 | **CVE-2026-44405** | *(none yet)* | SSH library — monitor upstream for patch |
+| `diskcache` | 5.6.3 | **CVE-2025-69872** | *(none yet)* | Cache layer — monitor upstream for patch |
+
+> 両 CVE とも修正バージョンが存在しないため、アップグレードによる解消は現時点で不可。
+> Upstream リリースを週次で追跡し、修正版が公開され次第即時アップグレードすること。
+
+---
+
+## ⚠ Outdated Dependencies (Major updates only)
+
+| Package | Current | Latest | Risk |
+|---|---|---|---|
+| `cryptography` | 41.0.7 | **48.0.0** | 🔴 High — 7 major versions behind; security fixes likely included |
+| `setuptools` | 68.1.2 | **82.0.1** | 🟠 Medium — build toolchain |
+| `pip` | 24.0 | **26.1.1** | 🟡 Low — package manager |
+| `packaging` | 24.0 | **26.2** | 🟡 Low |
+| `xmltodict` | 0.13.0 | **1.0.4** | 🟠 Medium — API break possible |
+| `wadllib` | 1.3.6 | **2.0.0** | 🟠 Medium — API break possible |
+| `launchpadlib` | 1.11.0 | **2.1.0** | 🟡 Low — dev tooling |
+
+> `cryptography` の大幅な遅れは最優先で対応を推奨。
+
+---
+
+## 📋 Bandit Findings (High/Medium only)
+
+### B608 — Possible SQL Injection (Medium)
+
+| File | Line | Severity | Confidence | CWE |
+|---|---|---|---|---|
+| `core/conversation_search.py` | 306 | Medium | Medium | CWE-89 |
+| `core/conversation_search.py` | 368 | Medium | Low | CWE-89 |
+
+**Detail:** f-string でテーブル名・カラム名を SQL に直接埋め込んでいる。
+`core/memory.py:733,779,875` および `core/memory_compressor.py:94` は `# nosec` 注釈済みで bandit がスキップ (意図的な抑制として記録)。
+
+### B310 — URL Open (Medium)
+
+| File | Line | Severity | Confidence | CWE |
+|---|---|---|---|---|
+| `core/github_learner.py` | 180 | Medium | High | CWE-22 |
+| `core/image_gen.py` | 156 | Medium | High | CWE-22 |
+| `core/research_agent.py` | 198 | Medium | High | CWE-22 |
+
+**Detail:** `urllib.request.urlopen` に `file://` や任意スキームが渡せる可能性。
+各所に `# noqa: S310` が付いており開発者が認識済みだが、URL のスキーム検証コードが存在するか要確認。
+
+### B601 — Paramiko Shell Injection (Medium)
+
+| File | Line | Severity | Confidence | CWE |
+|---|---|---|---|---|
+| `core/server_home.py` | 241 | Medium | Medium | CWE-78 |
+| `core/server_home.py` | 265 | Medium | Medium | CWE-78 |
+| `core/server_home.py` | 298 | Medium | Medium | CWE-78 |
+| `core/server_home.py` | 302 | Medium | Medium | CWE-78 |
+| `core/server_home.py` | 306 | Medium | Medium | CWE-78 |
+| `core/server_home.py` | 312 | Medium | Medium | CWE-78 |
+
+**Detail:** `client.exec_command(cmd)` に外部入力が入る経路があると shell injection になりうる。
+`cmd` 変数の組み立て箇所 (line 265) を重点的に確認すること。
+
+---
+
+## 🔍 Secret Scan
+
+スキャンパターン: `sk-*`, `ghp_*`, `AKIA*`, `-----BEGIN *PRIVATE KEY-----`
+対象拡張子: `.py` `.json` `.yaml` `.yml`
+
+**検出件数: 0 — クリーン ✅**
+
+---
+
+## Δ Delta vs 前日
+
+前日ログ `logs/security/2026-05-30.md` が存在しないため差分比較はスキップ (初回 or 欠落)。
+
+---
+
+## 💡 Recommendations (優先度順)
+
+1. **[P1] `cryptography` を 48.0.0 へアップグレード**
+   41.x → 48.x の間に複数のセキュリティ修正が含まれる可能性が高い。
+   `pip install 'cryptography>=48.0.0'` 後に回帰テストを実施。
+
+2. **[P1] CVE-2026-44405 (paramiko) / CVE-2025-69872 (diskcache) を追跡**
+   修正バージョンが存在しないため今すぐのアップグレードは不可。
+   両パッケージの GitHub リリースページ/セキュリティアドバイザリを週次で確認する Issue をトラッカーに立てること。
+   緩和策として paramiko の SSH 接続先を trusted host のみに制限し、diskcache の入力を検証すること。
+
+3. **[P2] `core/server_home.py:265` の `exec_command(cmd)` 入力検証を強化**
+   `cmd` の組み立てロジックを確認し、外部入力がそのまま渡らないようにホワイトリスト検証を追加。
+
+4. **[P2] `core/conversation_search.py` の SQL 構築を parameterized query に移行**
+   テーブル名・カラム名はホワイトリスト検証後に文字列として埋め込む現実的な対応か、
+   動的部分を定数化して f-string を排除するリファクタリングを検討。
+
+5. **[P3] `urllib.request.urlopen` のスキーム検証を明示的に実装**
+   `github_learner.py`, `image_gen.py`, `research_agent.py` の各 URL 呼び出し前に
+   `urllib.parse.urlparse(url).scheme in ('https', 'http')` のチェックを追加。
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### bandit (summary)
+
+```
+Run started:2026-05-31 00:11:36.472217+00:00
+
+Code scanned:
+	Total lines of code: 54471
+	Total lines skipped (#nosec): 0
+	Total potential issues skipped due to specifically being disabled (e.g., #nosec BXXX): 10
+
+Run metrics:
+	Total issues (by severity):
+		Undefined: 0
+		Low: 365
+		Medium: 11
+		High: 0
+	Total issues (by confidence):
+		Undefined: 0
+		Low: 1
+		Medium: 10
+		High: 365
+Files skipped (0):
+```
+
+### pip list --outdated (all packages)
+
+```
+Package          Version  Latest   Type
+---------------- -------- -------- -----
+argcomplete      3.1.4    3.6.3    wheel
+blinker          1.7.0    1.9.0    wheel
+certifi          2026.2.25 2026.5.20 wheel
+charset-normalizer 3.4.6  3.4.7   wheel
+conan            2.27.0   2.29.0   wheel
+cryptography     41.0.7   48.0.0   wheel  [MAJOR]
+dbus-python      1.3.2    1.4.0    wheel
+httplib2         0.20.4   0.31.2   wheel
+idna             3.11     3.17     wheel
+launchpadlib     1.11.0   2.1.0    wheel  [MAJOR]
+lazr.uri         1.0.6    1.0.8    wheel
+oauthlib         3.2.2    3.3.1    wheel
+packaging        24.0     26.2     wheel  [MAJOR]
+patch-ng         1.18.1   1.19.1   wheel
+pip              24.0     26.1.1   wheel  [MAJOR]
+PyGObject        3.48.2   3.56.3   wheel
+PyJWT            2.7.0    2.13.0   wheel
+pyparsing        3.1.1    3.3.2    wheel
+PyYAML           6.0.1    6.0.3    wheel
+requests         2.33.1   2.34.2   wheel
+setuptools       68.1.2   82.0.1   wheel  [MAJOR]
+six              1.16.0   1.17.0   wheel
+urllib3          2.6.3    2.7.0    wheel
+wadllib          1.3.6    2.0.0    wheel  [MAJOR]
+wheel            0.42.0   0.47.0   wheel
+xmltodict        0.13.0   1.0.4    wheel  [MAJOR]
+yq               3.1.0    3.4.3    wheel
+```
+
+### Secret scan
+
+```
+(No hits — 0 matches across *.py *.json *.yaml *.yml)
+```
+
+</details>


### PR DESCRIPTION
# 🛡 Daily Security Audit — 2026-05-31

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---|---|---|---|---|
| pip-audit (CVEs) | 0 | 2 ⚠️ | 0 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| Secret Scan | — | — | — | 0 ✅ |
| Outdated (major) | — | — | — | 7 |

## 🚨 HIGH — Unpatched CVEs

| Package | Version | CVE | Fix Available |
|---|---|---|---|
| `paramiko` | 3.5.1 | CVE-2026-44405 | ❌ none yet |
| `diskcache` | 5.6.3 | CVE-2025-69872 | ❌ none yet |

両 CVE とも修正バージョン未公開。upstream を週次追跡すること。

## ⚠ Major Version Gaps

- `cryptography` 41.0.7 → **48.0.0** 🔴 (7 major versions behind)
- `setuptools` 68.1.2 → 82.0.1
- `xmltodict` 0.13.0 → 1.0.4
- `wadllib` 1.3.6 → 2.0.0
- `packaging` 24.0 → 26.2
- `pip` 24.0 → 26.1.1
- `launchpadlib` 1.11.0 → 2.1.0

## 📋 Bandit Medium Findings (11 total)

- **B608 SQL injection** — `core/conversation_search.py:306,368`
- **B310 URL open** — `core/github_learner.py:180`, `core/image_gen.py:156`, `core/research_agent.py:198`
- **B601 Paramiko exec** — `core/server_home.py:241,265,298,302,306,312`

## 💡 Top Recommendations

1. **[P1]** Upgrade `cryptography` to 48.0.0 immediately
2. **[P1]** Track CVE-2026-44405 / CVE-2025-69872 — add weekly reminder
3. **[P2]** Harden `exec_command(cmd)` input at `server_home.py:265`
4. **[P2]** Migrate SQL f-strings in `conversation_search.py` to parameterized queries
5. **[P3]** Add URL scheme validation before `urlopen` calls

---
*Generated by ai-chan security bot — 2026-05-31 UTC*
*Full report: `logs/security/2026-05-31.md`*

---
_Generated by [Claude Code](https://claude.ai/code/session_013GKMmio5Gcwzoe6YWnCiDi)_