### PR TITLE
[URGENT] 🚨 Security Audit 2026-06-01

### DIFF
--- a/logs/security/2026-06-01.md
+++ b/logs/security/2026-06-01.md
@@ -1,0 +1,190 @@
+# Security Audit Report — 2026-06-01
+
+| Field | Value |
+|---|---|
+| Date (UTC) | 2026-06-01 |
+| Commit SHA | 40bb06e |
+| pip-audit | 2.10.0 |
+| bandit | 1.9.4 |
+| Python | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| pip-audit | 0 | 1 | 1 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | 0 | — |
+| outdated (major) | — | — | — | 7 |
+
+> **pip-audit severity mapping:** CVE-2025-69872 (diskcache pickle RCE) → HIGH; CVE-2026-44405 (paramiko SHA-1) → MEDIUM
+
+---
+
+## 🚨 Critical / High Findings
+
+### CVE-2025-69872 — diskcache 5.6.3 (HIGH)
+- **Package:** `diskcache` 5.6.3
+- **Fix version:** No upstream fix released yet
+- **Description:** DiskCache through 5.6.3 uses Python `pickle` for serialization by default. An attacker with write access to the cache directory can inject a malicious pickle payload leading to arbitrary code execution on cache read.
+- **Recommendation:** Disable pickle serialization or replace diskcache with a backend that uses safe serialization (e.g. JSON/msgpack). Monitor upstream for a patched release.
+
+---
+
+## ⚠ Medium Findings (pip-audit)
+
+### CVE-2026-44405 — paramiko 3.5.1 (MEDIUM)
+- **Package:** `paramiko` 3.5.1
+- **Fix version:** No upstream fix released yet (affects through 4.0.0 before a448945)
+- **Description:** `rsakey.py` allows the SHA-1 algorithm, which is cryptographically weak and susceptible to collision attacks, potentially enabling signature forgery on RSA keys.
+- **Recommendation:** Pin to a commit after a448945 or vendor the fix. Prefer Ed25519/ECDSA key types to avoid SHA-1 RSA paths.
+
+---
+
+## ⚠ Outdated Dependencies (Major Version Bumps)
+
+| Package | Current | Latest | Notes |
+|---|---|---|---|
+| cryptography | 41.0.7 | 48.0.0 | **Security-sensitive** — 7 major versions behind |
+| setuptools | 68.1.2 | 82.0.1 | Build toolchain |
+| pip | 24.0 | 26.1.2 | Package manager |
+| packaging | 24.0 | 26.2 | |
+| xmltodict | 0.13.0 | 1.0.4 | |
+| wadllib | 1.3.6 | 2.0.0 | |
+| launchpadlib | 1.11.0 | 2.1.0 | |
+
+> Total outdated packages: 27 (7 major, 20 minor/patch)
+
+---
+
+## 📋 Bandit Findings (Medium severity)
+
+| # | File:Line | Issue ID | Summary |
+|---|---|---|---|
+| 1 | `core/conversation_search.py:306` | B608 | SQL injection via f-string query (Confidence: Medium) |
+| 2 | `core/conversation_search.py:368` | B608 | SQL injection via f-string query (Confidence: Low) |
+| 3 | `core/github_learner.py:180` | B310 | `urllib.request.urlopen` — unvalidated scheme (Confidence: High) |
+| 4 | `core/image_gen.py:156` | B310 | `urllib.request.urlopen` — unvalidated scheme (Confidence: High) |
+| 5 | `core/research_agent.py:198` | B310 | `urllib.request.urlopen` — unvalidated scheme (Confidence: High) |
+| 6 | `core/server_home.py:241` | B601 | `paramiko exec_command` — possible shell injection (Confidence: Medium) |
+| 7 | `core/server_home.py:265` | B601 | `paramiko exec_command` — possible shell injection (Confidence: Medium) |
+| 8 | `core/server_home.py:298` | B601 | `paramiko exec_command` — possible shell injection (Confidence: Medium) |
+| 9 | `core/server_home.py:302` | B601 | `paramiko exec_command` — possible shell injection (Confidence: Medium) |
+| 10 | `core/server_home.py:306` | B601 | `paramiko exec_command` — possible shell injection (Confidence: Medium) |
+| 11 | `core/server_home.py:312` | B601 | `paramiko exec_command` — possible shell injection (Confidence: Medium) |
+
+**Low findings:** 365 (not listed; run `bandit -r core utils web ui -l` for full output)
+
+---
+
+## 🔍 Secret Scan
+
+**No secrets detected.** Patterns scanned: `sk-*` (OpenAI), `ghp_*` (GitHub PAT), `AKIA*` (AWS), PEM private key headers.
+
+---
+
+## Delta vs Previous Day
+
+No previous report found at `logs/security/2026-05-31.md` — this is the baseline audit.
+
+---
+
+## Recommendations (Priority Order)
+
+1. **[HIGH] Mitigate diskcache pickle RCE (CVE-2025-69872)** — Audit all cache write paths. If cache storage is accessible by untrusted parties, switch to a safe serializer or restrict directory permissions (mode 700) immediately. Track upstream for a fix release.
+
+2. **[HIGH] Upgrade `cryptography` 41 → 48** — Seven major versions behind on the core crypto library. Run `pip install --upgrade cryptography` and validate TLS/cipher dependent code. This is the single highest-impact dependency upgrade.
+
+3. **[MEDIUM] Address paramiko SHA-1 (CVE-2026-44405)** — Prefer Ed25519 keys in `core/server_home.py`. Vendor the upstream fix commit or watch for a 3.x/4.x patch release.
+
+4. **[MEDIUM] Review B608 SQL construction in `core/conversation_search.py:306,368`** — Validate that all interpolated identifiers (column names, table names) are whitelist-checked and never derived from user input. Consider using `sqlite3` identifier quoting helpers.
+
+5. **[LOW] Batch-upgrade minor/patch packages** — 20 packages have minor/patch updates. Run `pip install --upgrade -r requirements.txt` in a test environment; especially `certifi`, `requests`, `urllib3`, and `idna` which are on the network stack.
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip list --outdated
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.5.20 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.29.0    wheel
+cryptography       41.0.7    48.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.17      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.2    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.13.0    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+requests           2.33.1    2.34.2    wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+### bandit (full text)
+
+```
+Run started:2026-06-01 00:10:23.877857+00:00
+
+Test results:
+>> Issue: [B608] Possible SQL injection via f-string
+   Severity: Medium   Confidence: Medium
+   Location: core/conversation_search.py:306
+
+>> Issue: [B608] Possible SQL injection via f-string
+   Severity: Medium   Confidence: Low
+   Location: core/conversation_search.py:368
+
+>> Issue: [B310] urllib.request.urlopen unvalidated scheme
+   Severity: Medium   Confidence: High
+   Location: core/github_learner.py:180
+
+>> Issue: [B310] urllib.request.urlopen unvalidated scheme
+   Severity: Medium   Confidence: High
+   Location: core/image_gen.py:156
+
+>> Issue: [B310] urllib.request.urlopen unvalidated scheme
+   Severity: Medium   Confidence: High
+   Location: core/research_agent.py:198
+
+>> Issue: [B601] paramiko exec_command shell injection risk
+   Severity: Medium   Confidence: Medium
+   Locations: core/server_home.py:241, :265, :298, :302, :306, :312
+
+Run metrics:
+  Total lines of code: 54471
+  Total issues: High: 0, Medium: 11, Low: 365
+```
+
+</details>

--- a/logs/security/2026-06-01.md
+++ b/logs/security/2026-06-01.md
@@ -85,9 +85,19 @@
 
 ---
 
-## Delta vs Previous Day
+## Delta vs Previous Day (2026-05-31, PR #75)
 
-No previous report found at `logs/security/2026-05-31.md` — this is the baseline audit.
+| Finding | 2026-05-31 | 2026-06-01 | Change |
+|---|---|---|---|
+| pip-audit CRITICAL | 0 | 0 | no change |
+| pip-audit HIGH | 2 | 1 | -1 (paramiko reclassified MEDIUM) |
+| pip-audit MEDIUM | 0 | 1 | +1 (paramiko) |
+| bandit HIGH | 0 | 0 | no change |
+| bandit MEDIUM | 11 | 11 | no change |
+| secrets | 0 | 0 | no change |
+| outdated major | 7 | 7 | no change |
+
+No new vulnerabilities introduced since yesterday. Both CVEs (diskcache, paramiko) remain unpatched upstream.
 
 ---
 


### PR DESCRIPTION
# [URGENT] 🚨 Security Audit 2026-06-01

> **Automated daily security audit** — ai-chan security bot | commit `40bb06e` | pip-audit 2.10.0 | bandit 1.9.4
> Issue: https://github.com/FIshota/AI/issues/77

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---|---|---|---|---|
| pip-audit | 0 | 1 | 1 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| secrets | — | — | 0 | — |
| outdated (major) | — | — | — | 7 |

## Delta vs 2026-05-31

No new vulnerabilities. Same 2 CVEs, same 11 bandit MEDIUM, same 7 major outdated packages — all unresolved upstream.

---

## 🚨 HIGH — CVE-2025-69872 · diskcache 5.6.3

DiskCache through 5.6.3 uses Python `pickle` for serialization by default. An attacker with write access to the cache directory can inject a malicious pickle payload leading to **arbitrary code execution** on cache read.
- No upstream fix released yet
- **Action:** `chmod 700 <cache_dir>`; migrate to `diskcache.JSONDisk` serializer

## MEDIUM — CVE-2026-44405 · paramiko 3.5.1

`rsakey.py` allows the SHA-1 algorithm — cryptographically weak, susceptible to collision attacks.
- No upstream fix (affects through 4.0.0 before commit a448945)
- **Action:** Prefer Ed25519/ECDSA keys; vendor upstream fix

---

## ⚠ Outdated Dependencies (Major)

| Package | Current | Latest |
|---|---|---|
| cryptography | 41.0.7 | **48.0.0** 🔴 |
| setuptools | 68.1.2 | 82.0.1 |
| pip | 24.0 | 26.1.2 |
| packaging | 24.0 | 26.2 |
| xmltodict | 0.13.0 | 1.0.4 |
| wadllib | 1.3.6 | 2.0.0 |
| launchpadlib | 1.11.0 | 2.1.0 |

---

## 📋 Bandit Medium (11 findings)

| Test ID | File:Line | Issue |
|---|---|---|
| B608 | `core/conversation_search.py:306` | SQL injection via f-string |
| B608 | `core/conversation_search.py:368` | SQL injection via f-string |
| B310 | `core/github_learner.py:180` | urlopen unvalidated scheme |
| B310 | `core/image_gen.py:156` | urlopen unvalidated scheme |
| B310 | `core/research_agent.py:198` | urlopen unvalidated scheme |
| B601 | `core/server_home.py:241,265,298,302,306,312` | paramiko exec_command shell injection risk |

---

## Recommendations (Priority Order)

1. **[HIGH]** Mitigate diskcache pickle RCE — restrict cache dir permissions now
2. **[HIGH]** Upgrade `cryptography` 41 → 48 (7 major versions behind, security-critical)
3. **[MEDIUM]** Address paramiko SHA-1 (CVE-2026-44405)
4. **[MEDIUM]** Review B608 SQL f-strings in `core/conversation_search.py:306,368`
5. **[LOW]** Batch-upgrade minor/patch packages (certifi, requests, urllib3, idna)

---
Full report: `logs/security/2026-06-01.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_014H1JTWxPyY9TTSENGvVWkZ)_