### PR TITLE
[URGENT] 🚨 Security Audit 2026-06-06

### DIFF
--- a/logs/security/2026-06-06.md
+++ b/logs/security/2026-06-06.md
@@ -1,0 +1,174 @@
+# 🛡 Security Audit Report — 2026-06-06
+
+| Item | Value |
+|------|-------|
+| **Date (UTC)** | 2026-06-06 |
+| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| **pip-audit** | 2.10.0 |
+| **bandit** | 1.9.4 (Python 3.11.15) |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---------|----------|------|--------|-----|
+| pip-audit (CVE) | 0 | 1 | 1 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| Secret Scan | — | — | — | 0 |
+| Outdated (major) | — | — | — | 7 |
+
+---
+
+## 🚨 Critical / High Findings
+
+### CVE-2025-69872 — `diskcache` 5.6.3 · **HIGH**
+- **Aliases:** GHSA-w8v5-vhqr-4h9v
+- **Fix Versions:** none available yet (upstream unfixed as of scan date)
+- **Description:** DiskCache through 5.6.3 uses Python `pickle` for serialization by default. An attacker with **write access to the cache directory** can achieve **arbitrary code execution** when a victim application reads from the cache.
+- **Recommendation:** Restrict cache directory permissions; consider switching serializer to `json` or `msgpack`; monitor upstream for patch.
+
+---
+
+## ⚠ Medium Findings (pip-audit)
+
+### CVE-2026-44405 — `paramiko` 3.5.1 · **MEDIUM**
+- **Aliases:** GHSA-r374-rxx8-8654
+- **Fix Versions:** none available yet (upstream: commit `a448945`)
+- **Description:** Paramiko through 4.0.0 allows the **SHA-1 algorithm** in `rsakey.py`, which is cryptographically weak.
+- **Recommendation:** Pin to the patched commit once released; disable SHA-1 host key negotiation in SSH client configuration.
+
+---
+
+## ⚠ Outdated Dependencies (major version upgrades only)
+
+| Package | Current | Latest |
+|---------|---------|--------|
+| `cryptography` | 41.0.7 | **48.0.0** |
+| `launchpadlib` | 1.11.0 | **2.1.0** |
+| `packaging` | 24.0 | **26.2** |
+| `pip` | 24.0 | **26.1.2** |
+| `setuptools` | 68.1.2 | **82.0.1** |
+| `wadllib` | 1.3.6 | **2.0.0** |
+| `xmltodict` | 0.13.0 | **1.0.4** |
+
+> Total outdated packages: **27** (including minor/patch).
+
+---
+
+## 📋 Bandit Findings (Medium severity, 11 total)
+
+| Severity | Test ID | File | Line | Issue |
+|----------|---------|------|------|-------|
+| MEDIUM | B608 | `core/conversation_search.py` | 306 | SQL injection via f-string query construction |
+| MEDIUM | B608 | `core/conversation_search.py` | 368 | SQL injection via f-string query construction |
+| MEDIUM | B310 | `core/github_learner.py` | 180 | `urllib.request.urlopen` — unapproved URL schemes |
+| MEDIUM | B310 | `core/image_gen.py` | 156 | `urllib.request.urlopen` — unapproved URL schemes |
+| MEDIUM | B310 | `core/research_agent.py` | 198 | `urllib.request.urlopen` — unapproved URL schemes |
+| MEDIUM | B601 | `core/server_home.py` | 241 | Paramiko `exec_command` — possible shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 265 | Paramiko `exec_command` — possible shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 298 | Paramiko `exec_command` — possible shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 302 | Paramiko `exec_command` — possible shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 306 | Paramiko `exec_command` — possible shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 312 | Paramiko `exec_command` — possible shell injection |
+
+> Notes: 365 LOW findings omitted. 10 `#nosec` suppressions present in codebase (B608 ×4, B507 ×1 already reviewed).
+
+---
+
+## 🔍 Secret Scan
+
+No secrets detected. ✅
+
+---
+
+## Delta vs Previous Day (2026-06-05 — PR #86)
+
+| Metric | 2026-06-05 | 2026-06-06 | Change |
+|--------|-----------|-----------|--------|
+| pip-audit HIGH | 2 | 1 | -1 (reclassification: paramiko → MEDIUM) |
+| pip-audit MEDIUM | 0 | 1 | +1 (paramiko SHA-1 reclassified) |
+| bandit MEDIUM | 11 | 11 | ± 0 |
+| bandit LOW | 365 | 365 | ± 0 |
+| Secrets | 0 | 0 | ± 0 |
+| Outdated major | 5 | 7 | +2 (`packaging`, `pip` now flagged) |
+
+**No new CVEs introduced. Same 2 unpatched CVEs remain open upstream.**
+
+---
+
+## Recommendations (priority order)
+
+1. **[HIGH — Immediate] Mitigate CVE-2025-69872 (diskcache RCE):** Audit all locations that write to the DiskCache directory. Restrict OS-level permissions (`chmod 700`) and consider replacing the default `pickle` serializer. Track upstream `python-diskcache` for patch release.
+
+2. **[HIGH — Short-term] Upgrade `cryptography` 41.0.7 → 48.0.0:** Seven major versions behind; this library is a core security dependency. Test compatibility and upgrade in an isolated branch.
+
+3. **[MEDIUM — Short-term] Resolve CVE-2026-44405 (paramiko SHA-1):** Once upstream releases a patched wheel, pin to it. In the interim, configure SSH clients to reject SHA-1 in `~/.ssh/config` (`HostKeyAlgorithms -ssh-rsa`).
+
+4. **[MEDIUM — Planned] Review B608 SQL injection patterns in `core/conversation_search.py`:** Lines 306 and 368 build queries with f-strings. Verify all interpolated values are strictly allowlisted identifiers (column/table names), never user-supplied data. Add an explicit allowlist check and document it.
+
+5. **[LOW — Housekeeping] Batch-upgrade 27 outdated packages:** Prioritise `setuptools`, `pip`, `packaging` (build toolchain) and `xmltodict` / `wadllib` (API parsers). Schedule a dependency-refresh PR separate from feature work.
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip-audit (JSON excerpt)
+
+```json
+[
+  {
+    "pkg": "paramiko",
+    "ver": "3.5.1",
+    "id": "CVE-2026-44405",
+    "aliases": ["GHSA-r374-rxx8-8654"],
+    "fix": [],
+    "description": "In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm."
+  },
+  {
+    "pkg": "diskcache",
+    "ver": "5.6.3",
+    "id": "CVE-2025-69872",
+    "aliases": ["GHSA-w8v5-vhqr-4h9v"],
+    "fix": [],
+    "description": "DiskCache (python-diskcache) through 5.6.3 uses Python pickle for serialization by default. An attacker with write access to the cache directory can achieve arbitrary code execution when a victim application reads from the cache."
+  }
+]
+```
+
+### bandit summary
+
+```
+Total lines of code: 54471
+Total issues (by severity):
+    Undefined: 0  Low: 365  Medium: 11  High: 0
+Total issues (by confidence):
+    Undefined: 0  Low: 1  Medium: 10  High: 365
+Files skipped: 0
+nosec suppressions active: 10
+```
+
+### Outdated Dependencies (27 total, major upgrades shown)
+
+```
+cryptography   41.0.7   -> 48.0.0
+launchpadlib   1.11.0   -> 2.1.0
+packaging      24.0     -> 26.2
+pip            24.0     -> 26.1.2
+setuptools     68.1.2   -> 82.0.1
+wadllib        1.3.6    -> 2.0.0
+xmltodict      0.13.0   -> 1.0.4
+```
+
+</details>


### PR DESCRIPTION
# 🛡 Security Audit Report — 2026-06-06

| Item | Value |
|------|-------|
| **Date (UTC)** | 2026-06-06 |
| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
| **pip-audit** | 2.10.0 |
| **bandit** | 1.9.4 (Python 3.11.15) |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---------|----------|------|--------|-----|
| pip-audit (CVE) | 0 | 1 | 1 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| Secret Scan | — | — | — | 0 |
| Outdated (major) | — | — | — | 7 |

---

## 🚨 Critical / High Findings

### CVE-2025-69872 — `diskcache` 5.6.3 · **HIGH**
- **Aliases:** GHSA-w8v5-vhqr-4h9v
- **Fix Versions:** none available yet (upstream unfixed as of scan date)
- **Description:** DiskCache through 5.6.3 uses Python `pickle` for serialization by default. An attacker with **write access to the cache directory** can achieve **arbitrary code execution** when a victim application reads from the cache.
- **Recommendation:** Restrict cache directory permissions; consider switching serializer to `json` or `msgpack`; monitor upstream for patch.

---

## ⚠ Medium Findings (pip-audit)

### CVE-2026-44405 — `paramiko` 3.5.1 · **MEDIUM**
- **Aliases:** GHSA-r374-rxx8-8654
- **Fix Versions:** none available yet (upstream: commit `a448945`)
- **Description:** Paramiko through 4.0.0 allows the **SHA-1 algorithm** in `rsakey.py`, which is cryptographically weak.
- **Recommendation:** Pin to the patched commit once released; disable SHA-1 host key negotiation in SSH client configuration.

---

## ⚠ Outdated Dependencies (major version upgrades only)

| Package | Current | Latest |
|---------|---------|--------|
| `cryptography` | 41.0.7 | **48.0.0** |
| `launchpadlib` | 1.11.0 | **2.1.0** |
| `packaging` | 24.0 | **26.2** |
| `pip` | 24.0 | **26.1.2** |
| `setuptools` | 68.1.2 | **82.0.1** |
| `wadllib` | 1.3.6 | **2.0.0** |
| `xmltodict` | 0.13.0 | **1.0.4** |

> Total outdated packages: **27** (including minor/patch).

---

## 📋 Bandit Findings (Medium severity, 11 total)

| Severity | Test ID | File | Line | Issue |
|----------|---------|------|------|-------|
| MEDIUM | B608 | `core/conversation_search.py` | 306 | SQL injection via f-string query construction |
| MEDIUM | B608 | `core/conversation_search.py` | 368 | SQL injection via f-string query construction |
| MEDIUM | B310 | `core/github_learner.py` | 180 | `urllib.request.urlopen` — unapproved URL schemes |
| MEDIUM | B310 | `core/image_gen.py` | 156 | `urllib.request.urlopen` — unapproved URL schemes |
| MEDIUM | B310 | `core/research_agent.py` | 198 | `urllib.request.urlopen` — unapproved URL schemes |
| MEDIUM | B601 | `core/server_home.py` | 241 | Paramiko `exec_command` — possible shell injection |
| MEDIUM | B601 | `core/server_home.py` | 265 | Paramiko `exec_command` — possible shell injection |
| MEDIUM | B601 | `core/server_home.py` | 298 | Paramiko `exec_command` — possible shell injection |
| MEDIUM | B601 | `core/server_home.py` | 302 | Paramiko `exec_command` — possible shell injection |
| MEDIUM | B601 | `core/server_home.py` | 306 | Paramiko `exec_command` — possible shell injection |
| MEDIUM | B601 | `core/server_home.py` | 312 | Paramiko `exec_command` — possible shell injection |

> Notes: 365 LOW findings omitted. 10 `#nosec` suppressions present in codebase.

---

## 🔍 Secret Scan

No secrets detected. ✅

---

## Delta vs Previous Day (2026-06-05 — PR #86)

| Metric | 2026-06-05 | 2026-06-06 | Change |
|--------|-----------|-----------|--------|
| pip-audit HIGH | 2 | 1 | -1 (reclassification: paramiko → MEDIUM) |
| pip-audit MEDIUM | 0 | 1 | +1 (paramiko SHA-1 reclassified) |
| bandit MEDIUM | 11 | 11 | ± 0 |
| bandit LOW | 365 | 365 | ± 0 |
| Secrets | 0 | 0 | ± 0 |
| Outdated major | 5 | 7 | +2 (`packaging`, `pip` now flagged) |

**No new CVEs introduced. Same 2 unpatched CVEs remain open upstream.**

---

## Recommendations (priority order)

1. **[HIGH — Immediate] Mitigate CVE-2025-69872 (diskcache RCE):** Audit all locations that write to the DiskCache directory. Restrict OS-level permissions (`chmod 700`) and consider replacing the default `pickle` serializer. Track upstream `python-diskcache` for patch release.

2. **[HIGH — Short-term] Upgrade `cryptography` 41.0.7 → 48.0.0:** Seven major versions behind; this library is a core security dependency. Test compatibility and upgrade in an isolated branch.

3. **[MEDIUM — Short-term] Resolve CVE-2026-44405 (paramiko SHA-1):** Once upstream releases a patched wheel, pin to it. In the interim, configure SSH clients to reject SHA-1 in `~/.ssh/config` (`HostKeyAlgorithms -ssh-rsa`).

4. **[MEDIUM — Planned] Review B608 SQL injection patterns in `core/conversation_search.py`:** Lines 306 and 368 build queries with f-strings. Verify all interpolated values are strictly allowlisted identifiers (column/table names), never user-supplied data.

5. **[LOW — Housekeeping] Batch-upgrade 27 outdated packages:** Prioritise `setuptools`, `pip`, `packaging` (build toolchain) and `xmltodict` / `wadllib` (API parsers).

---

<details>
<summary>Raw Outputs</summary>

### pip-audit

```
Found 2 known vulnerabilities in 2 packages
Name      Version ID             Fix Versions
--------- ------- -------------- ------------
paramiko  3.5.1   CVE-2026-44405
diskcache 5.6.3   CVE-2025-69872
```

### bandit summary

```
Total lines of code: 54471
Total issues (by severity):
    Low: 365  Medium: 11  High: 0
nosec suppressions active: 10
```

### Outdated (major upgrades)

```
cryptography   41.0.7   -> 48.0.0
launchpadlib   1.11.0   -> 2.1.0
packaging      24.0     -> 26.2
pip            24.0     -> 26.1.2
setuptools     68.1.2   -> 82.0.1
wadllib        1.3.6    -> 2.0.0
xmltodict      0.13.0   -> 1.0.4
```

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTWfsgwwFdJFJCvKChuEWN)_