### PR TITLE
[URGENT] 🚨 Security Audit 2026-06-07

### DIFF
--- a/logs/security/2026-06-07.md
+++ b/logs/security/2026-06-07.md
@@ -1,0 +1,202 @@
+# 🛡 Security Audit Report — 2026-06-07
+
+| Field | Value |
+|-------|-------|
+| **Date (UTC)** | 2026-06-07 |
+| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| **pip-audit** | 2.10.0 |
+| **bandit** | 1.9.4 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---------|:--------:|:----:|:------:|:---:|
+| pip-audit | 0 | 2 | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | 0 | — |
+| outdated (major ver.) | — | — | — | 1 |
+
+---
+
+## 🚨 Critical / High Findings
+
+### pip-audit — CVE Findings
+
+| CVE | GHSA | Package | Installed | Fix Version | Summary |
+|-----|------|---------|-----------|:-----------:|--------|
+| CVE-2026-44405 | GHSA-r374-rxx8-8654 | `paramiko` | 3.5.1 | **なし** | `rsakey.py` が SHA-1 アルゴリズムを許可。非推奨アルゴリズムによる中間者攻撃リスク。 |
+| CVE-2025-69872 | GHSA-w8v5-vhqr-4h9v | `diskcache` | 5.6.3 | **なし** | デフォルト pickle シリアライズによる RCE リスク。キャッシュへの書き込みアクセスを持つ攻撃者が悪用可能。 |
+
+> ⚠ 両 CVE とも **現時点でアップストリームの修正バージョンなし**。GHSA アドバイザリを監視し、workaround を適用すること。
+
+---
+
+## ⚠ Outdated Dependencies (メジャー更新のみ)
+
+| Package | Installed | Latest | requirements.txt | 備考 |
+|---------|-----------|--------|-----------------|------|
+| `cryptography` | 41.0.7 | 48.0.0 | `>=46.0.7` | ⚠ **インストール版が要件最小値未満** |
+
+> 🔴 **緊急**: `cryptography 41.0.7` は `requirements.txt` の `>=46.0.7` を満たしていません。`pip install --upgrade cryptography` を即時実行してください。
+
+---
+
+## 📋 Bandit Findings (High / Medium のみ)
+
+| Severity | ID | File:Line | CWE | Issue |
+|----------|:--:|-----------|:---:|-------|
+| MEDIUM | B608 | `core/conversation_search.py:306` | CWE-89 | f-string による SQL クエリ構築 — SQL インジェクションベクター |
+| MEDIUM | B608 | `core/conversation_search.py:368` | CWE-89 | f-string による SQL クエリ構築 — SQL インジェクションベクター |
+| MEDIUM | B310 | `core/github_learner.py:180` | CWE-22 | `urllib.request.urlopen` — `file:/` スキーム許可リスク |
+| MEDIUM | B310 | `core/image_gen.py:156` | CWE-22 | `urllib.request.urlopen` — `file:/` スキーム許可リスク |
+| MEDIUM | B310 | `core/research_agent.py:198` | CWE-22 | `urllib.request.urlopen` — `file:/` スキーム許可リスク |
+| MEDIUM | B601 | `core/server_home.py:241` | CWE-78 | `paramiko.exec_command` — シェルインジェクションリスク |
+| MEDIUM | B601 | `core/server_home.py:265` | CWE-78 | `paramiko.exec_command` — シェルインジェクションリスク |
+| MEDIUM | B601 | `core/server_home.py:298` | CWE-78 | `paramiko.exec_command` — シェルインジェクションリスク |
+| MEDIUM | B601 | `core/server_home.py:302` | CWE-78 | `paramiko.exec_command` — シェルインジェクションリスク |
+| MEDIUM | B601 | `core/server_home.py:306` | CWE-78 | `paramiko.exec_command` — シェルインジェクションリスク |
+| MEDIUM | B601 | `core/server_home.py:312` | CWE-78 | `paramiko.exec_command` — シェルインジェクションリスク |
+
+---
+
+## 🔍 Secret Scan
+
+```
+スキャン対象: **/*.py, **/*.json, **/*.yaml, **/*.yml
+パターン: sk-*, ghp_*, AKIA*, -----BEGIN *PRIVATE KEY-----
+
+検出件数: 0
+```
+
+シークレット漏洩は検出されませんでした。✅
+
+---
+
+## Delta vs 前回 (2026-05-24)
+
+前回監査: `security/audit-2026-05-24` ブランチ (14 日前)
+
+| 項目 | 前回 (05-24) | 今回 (06-07) | 変化 |
+|------|:-----------:|:-----------:|:----:|
+| pip-audit HIGH CVEs | 2 | 2 | ➡ 変化なし |
+| bandit MEDIUM | 11 | 11 | ➡ 変化なし |
+| bandit HIGH | 0 | 0 | ➡ 変化なし |
+| Secrets | 0 | 0 | ➡ 変化なし |
+
+**新規 findings: なし**  
+**修正済み findings: なし**
+
+> ⚠ CVE-2026-44405 (paramiko) および CVE-2025-69872 (diskcache) は 14 日間解消されていません。引き続きアップストリームの修正リリースを監視してください。
+
+---
+
+## Recommendations
+
+優先度順:
+
+1. **🔴 [緊急] `cryptography` を 46.0.7+ に即時アップグレード**  
+   インストール版 41.0.7 は `requirements.txt` の最小要件 (`>=46.0.7`) を下回っており、既知の暗号ライブラリの脆弱性にさらされている可能性があります。
+   ```bash
+   pip install --upgrade cryptography
+   ```
+
+2. **🔴 [HIGH] `paramiko` CVE-2026-44405 の workaround 適用**  
+   現時点でパッチなし。SSH 接続で RSA キーを使用する `core/server_home.py` で SHA-1 を明示的に無効化:
+   ```python
+   transport.disabled_algorithms = {"pubkeys": ["rsa-sha2-256"], "keys": ["rsa-sha2-256"]}
+   ```
+   `requirements.txt` コメントの通り `paramiko 4.x` 移行も再検討。
+
+3. **🟠 [HIGH] `diskcache` CVE-2025-69872 の pickle 依存を排除**  
+   `requirements.txt` に「`_secure_cache_dir()` で mitigated」と記述あり — その実装が攻撃者書き込みを確実に防いでいるか再検証してください。  
+   完全対策: `DiskCache(disk=JSONDisk)` 等 pickle 非依存ディスクに切替。
+
+4. **🟡 [MEDIUM] `core/conversation_search.py` SQL クエリをパラメータ化**  
+   テーブル名・カラム名の f-string 補間を廃止し、ホワイトリストマッピングを導入:
+   ```python
+   ALLOWED_TABLES = {"conversations", "turns"}
+   if table not in ALLOWED_TABLES:
+       raise ValueError(f"Invalid table: {table}")
+   ```
+
+5. **🟡 [MEDIUM] `core/server_home.py` の `exec_command` 入力をハードコード化**  
+   外部入力をコマンド文字列に混入させず、実行コマンドをハードコード定数として管理。動的コマンド構築が必要な場合はシェルメタ文字をサニタイズ (`shlex.quote`)。
+
+---
+
+<details>
+<summary>📄 Raw outputs</summary>
+
+### pip-audit
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405 (none)
+diskcache 5.6.3   CVE-2025-69872 (none)
+```
+
+**pip-audit JSON 抜粋**:
+- paramiko 3.5.1: CVE-2026-44405 / GHSA-r374-rxx8-8654 — "In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm."
+- diskcache 5.6.3: CVE-2025-69872 / GHSA-w8v5-vhqr-4h9v — "DiskCache through 5.6.3 uses Python pickle for serialization by default. An attacker with write access..."
+
+### bandit metrics
+
+```
+Total lines of code: 54471
+Total lines skipped (#nosec): 0
+Skipped (disabled via #nosec BXXX): 10
+
+Severity breakdown:
+  HIGH:   0
+  MEDIUM: 11
+  LOW:    365
+
+Confidence breakdown:
+  HIGH:   365
+  MEDIUM: 10
+  LOW:    1
+```
+
+### pip list --outdated (全件)
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.5.20 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.29.0    wheel
+cryptography       41.0.7    48.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.18      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.2    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.13.0    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+requests           2.33.1    2.34.2    wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+</details>
+
+---
+
+*Generated by ai-chan security bot — UTC 2026-06-07*


### PR DESCRIPTION
# [URGENT] 🚨 Security Audit — 2026-06-07

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---------|:--------:|:----:|:------:|:---:|
| pip-audit | 0 | **2** | 0 | 0 |
| bandit | 0 | 0 | **11** | 365 |
| secrets | — | — | 0 | — |
| outdated (major) | — | — | — | 1 |

## 🚨 HIGH Findings (action required)

| CVE | Package | Installed | Fix |
|-----|---------|-----------|-----|
| CVE-2026-44405 | `paramiko` 3.5.1 | SHA-1 downgrade attack | 修正版なし — workaround 適用要 |
| CVE-2025-69872 | `diskcache` 5.6.3 | pickle RCE risk | 修正版なし — serialize=JSONDisk 推奨 |

> ⚠ 両 CVE は前回監査 (2026-05-24) から **14日間未解消**。

## ⚠ cryptography インストール版が requirements.txt 最小値未満

`cryptography 41.0.7` がインストールされていますが `requirements.txt` は `>=46.0.7` を要求しています。

```bash
pip install --upgrade cryptography
```

## Changes

- `logs/security/2026-06-07.md` — 日次セキュリティ監査レポート追加

## Test plan

- [ ] レポートファイル `logs/security/2026-06-07.md` の内容を確認
- [ ] CVE-2026-44405 (paramiko) の workaround 実装
- [ ] CVE-2025-69872 (diskcache) の mitigation 有効性を再確認
- [ ] `cryptography` を 46.0.7+ にアップグレード

*Generated by ai-chan security bot — UTC 2026-06-07*

---
_Generated by [Claude Code](https://claude.ai/code/session_01U532bbMsBG7qQ5MkH3MB3w)_