### PR TITLE
[URGENT] 🚨 Security Audit 2026-06-09

### DIFF
--- a/logs/security/2026-06-09.md
+++ b/logs/security/2026-06-09.md
@@ -1,0 +1,174 @@
+# 🛡 ai-chan Daily Security Audit — 2026-06-09
+
+| Field | Value |
+|---|---|
+| **Date (UTC)** | 2026-06-09 |
+| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| **pip-audit** | 2.10.0 |
+| **bandit** | 1.9.4 |
+| **Python** | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| pip-audit (CVEs) | 0 | 2 | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | 0 | — |
+| outdated (major) | — | — | — | 7 |
+
+---
+
+## 🚨 Critical / High Findings (pip-audit)
+
+| CVE | Package | Installed | Fix Version | Description |
+|---|---|---|---|---|
+| **CVE-2026-44405** | `paramiko` | 3.5.1 | None published yet | In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm (weak key exchange). Mitigate by disabling SHA-1 in server policy. |
+| **CVE-2025-69872** | `diskcache` | 5.6.3 | None published yet | DiskCache through 5.6.3 uses Python pickle serialization by default. Attacker with write access to cache directory can achieve arbitrary code execution. Currently mitigated via `_secure_cache_dir()`. |
+
+> **Note:** No official fix versions are available for either CVE as of audit date. Monitor upstream for patches.
+
+---
+
+## ⚠ Outdated Dependencies (major version upgrades only)
+
+| Package | Installed | Latest | Notes |
+|---|---|---|---|
+| `cryptography` | 41.0.7 | 48.0.0 | **Critical** — 7 major versions behind; security lib, upgrade priority HIGH |
+| `setuptools` | 68.1.2 | 82.0.1 | Build tooling, review changelog |
+| `pip` | 24.0 | 26.1.2 | Package manager itself |
+| `packaging` | 24.0 | 26.2 | Major bump |
+| `launchpadlib` | 1.11.0 | 2.1.0 | API may differ |
+| `wadllib` | 1.3.6 | 2.0.0 | |
+| `xmltodict` | 0.13.0 | 1.0.4 | |
+
+> Total outdated packages (all versions): 27
+
+---
+
+## 📋 Bandit Findings (High / Medium only)
+
+| Severity | Test ID | File:Line | Issue |
+|---|---|---|---|
+| MEDIUM | B608 | `core/conversation_search.py:306` | Possible SQL injection via f-string query construction (SELECT with f-string table/column names) |
+| MEDIUM | B608 | `core/conversation_search.py:368` | Possible SQL injection via string-concatenated query (BM25 search SQL) |
+| MEDIUM | B310 | `core/github_learner.py:180` | `urllib.request.urlopen` — audit URL schemes (file:/ risk) |
+| MEDIUM | B310 | `core/image_gen.py:156` | `urllib.request.urlopen` — audit URL schemes (file:/ risk) |
+| MEDIUM | B310 | `core/research_agent.py:198` | `urllib.request.urlopen` — audit URL schemes (file:/ risk) |
+| MEDIUM | B601 | `core/server_home.py:241` | Paramiko `exec_command("echo ok")` — hardcoded but flag raised |
+| MEDIUM | B601 | `core/server_home.py:265` | Paramiko `exec_command(cmd)` — `cmd` must be validated upstream |
+| MEDIUM | B601 | `core/server_home.py:298` | Paramiko `exec_command("uptime -p")` — hardcoded |
+| MEDIUM | B601 | `core/server_home.py:302` | Paramiko `exec_command("df -h / | tail -1")` — hardcoded |
+| MEDIUM | B601 | `core/server_home.py:306` | Paramiko `exec_command("free -h | grep Mem | awk …")` — hardcoded |
+| MEDIUM | B601 | `core/server_home.py:312` | Paramiko `exec_command("docker ps …")` — hardcoded |
+
+> Total LOW findings: 365 (skipped per policy — only High/Medium reported)  
+> 10 `#nosec` suppressions in place (B608 × 4 on `core/memory.py`, B507 × 1 on `core/server_home.py`)
+
+---
+
+## 🔍 Secret Scan
+
+**No secrets detected.** (Patterns: `sk-*`, `ghp_*`, `AKIA*`, PEM private keys)
+
+---
+
+## Delta vs 前日
+
+前日レポート (`logs/security/2026-06-08.md`) が存在しないため、差分比較不可。  
+*(初回または前日レポート欠落)*
+
+---
+
+## Recommendations (優先度順)
+
+1. **[P1] `cryptography` を 41.x → 48.x に即時アップグレード**  
+   セキュリティライブラリが 7 メジャーバージョン遅延。`requirements.txt` の下限を `>=48.0.0` に引き上げ、テストスイート実行後にマージ。
+
+2. **[P1] `paramiko` CVE-2026-44405 — SHA-1 無効化の強制確認**  
+   公式修正版未リリース。`core/server_home.py` の SSHClient 設定で `disabled_algorithms={"keys": ["rsa-sha1"]}` を明示設定し、接続ポリシーを強化。
+
+3. **[P2] `diskcache` CVE-2025-69872 — pickle 緩和策の追加テスト**  
+   `_secure_cache_dir()` による緩和が有効か確認。キャッシュディレクトリパーミッション (700) および書き込み権限をインテグレーションテストで検証。
+
+4. **[P3] `core/server_home.py` B601 — Paramiko `exec_command(cmd)` の入力検証**  
+   `core/server_home.py:265` の `cmd` 変数が外部入力から来る場合、許可リスト検証を追加。ハードコード行 (241, 298, 302, 306, 312) は低リスクだが bandit 抑制 (`# nosec B601`) を付与してノイズを削減。
+
+5. **[P3] `core/conversation_search.py` B608 — SQL クエリの安全化**  
+   テーブル名・カラム名の f-string 展開を allowlist チェック経由に変更、または SQLAlchemy の `text()` + `bindparam()` に移行。現在 nosec で抑制済みの箇所 (`core/memory.py`) と同様のパターンへ統一。
+
+---
+
+<details>
+<summary>📄 Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### pip list --outdated
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.5.20 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.29.0    wheel
+cryptography       41.0.7    48.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.18      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.2    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.13.0    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+requests           2.33.1    2.34.2    wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+### bandit (summary)
+
+```
+Run started: 2026-06-09 00:04:44 UTC
+Total lines of code: 54471
+Total lines skipped (#nosec): 0
+Suppressed issues (specific #nosec BXXX): 10
+
+Total issues by severity:
+  High:   0
+  Medium: 11
+  Low:    365
+
+Total issues by confidence:
+  High:   365 (Low-severity)
+  Medium: 10  (Medium-severity)
+  Low:    1   (Medium-severity)
+```
+
+</details>
+
+---
+
+*Generated by ai-chan security bot · UTC 2026-06-09*


### PR DESCRIPTION
# 🛡 ai-chan Daily Security Audit — 2026-06-09

| Field | Value |
|---|---|
| **Date (UTC)** | 2026-06-09 |
| **Commit SHA** | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
| **pip-audit** | 2.10.0 |
| **bandit** | 1.9.4 |
| **Python** | 3.11.15 |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---|---|---|---|---|
| pip-audit (CVEs) | 0 | **2** | 0 | 0 |
| bandit | 0 | 0 | **11** | 365 |
| secrets | — | — | 0 | — |
| outdated (major) | — | — | — | 7 |

---

## 🚨 Critical / High Findings (pip-audit)

| CVE | Package | Installed | Fix Version | Description |
|---|---|---|---|---|
| **CVE-2026-44405** | `paramiko` | 3.5.1 | None published yet | In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm (weak key exchange). Mitigate by disabling SHA-1 in server policy. |
| **CVE-2025-69872** | `diskcache` | 5.6.3 | None published yet | DiskCache through 5.6.3 uses Python pickle serialization by default. Attacker with write access to cache directory can achieve arbitrary code execution. Currently mitigated via `_secure_cache_dir()`. |

> **Note:** No official fix versions are available for either CVE as of audit date. Monitor upstream for patches.

---

## ⚠ Outdated Dependencies (major version upgrades only)

| Package | Installed | Latest | Notes |
|---|---|---|---|
| `cryptography` | 41.0.7 | 48.0.0 | **Critical** — 7 major versions behind; security lib, upgrade priority HIGH |
| `setuptools` | 68.1.2 | 82.0.1 | Build tooling, review changelog |
| `pip` | 24.0 | 26.1.2 | Package manager itself |
| `packaging` | 24.0 | 26.2 | Major bump |
| `launchpadlib` | 1.11.0 | 2.1.0 | API may differ |
| `wadllib` | 1.3.6 | 2.0.0 | |
| `xmltodict` | 0.13.0 | 1.0.4 | |

> Total outdated packages (all versions): 27

---

## 📋 Bandit Findings (High / Medium only)

| Severity | Test ID | File:Line | Issue |
|---|---|---|---|
| MEDIUM | B608 | `core/conversation_search.py:306` | Possible SQL injection via f-string query construction |
| MEDIUM | B608 | `core/conversation_search.py:368` | Possible SQL injection via string-concatenated query (BM25) |
| MEDIUM | B310 | `core/github_learner.py:180` | `urllib.request.urlopen` — audit URL schemes (file:/ risk) |
| MEDIUM | B310 | `core/image_gen.py:156` | `urllib.request.urlopen` — audit URL schemes (file:/ risk) |
| MEDIUM | B310 | `core/research_agent.py:198` | `urllib.request.urlopen` — audit URL schemes (file:/ risk) |
| MEDIUM | B601 | `core/server_home.py:241` | Paramiko `exec_command` |
| MEDIUM | B601 | `core/server_home.py:265` | Paramiko `exec_command(cmd)` — input validation required |
| MEDIUM | B601 | `core/server_home.py:298` | Paramiko `exec_command` |
| MEDIUM | B601 | `core/server_home.py:302` | Paramiko `exec_command` |
| MEDIUM | B601 | `core/server_home.py:306` | Paramiko `exec_command` |
| MEDIUM | B601 | `core/server_home.py:312` | Paramiko `exec_command` |

---

## 🔍 Secret Scan

**No secrets detected.** (Patterns: `sk-*`, `ghp_*`, `AKIA*`, PEM private keys)

---

## Recommendations (優先度順)

1. **[P1] `cryptography` を 41.x → 48.x に即時アップグレード**  
   セキュリティライブラリが 7 メジャーバージョン遅延。`requirements.txt` の下限を `>=48.0.0` に引き上げ。

2. **[P1] `paramiko` CVE-2026-44405 — SHA-1 無効化の強制確認**  
   `core/server_home.py` の SSHClient に `disabled_algorithms={"keys": ["rsa-sha1"]}` を設定。

3. **[P2] `diskcache` CVE-2025-69872 — pickle 緩和策の追加テスト**  
   キャッシュディレクトリパーミッション (700) をインテグレーションテストで検証。

4. **[P3] `core/server_home.py` B601 — Paramiko `exec_command(cmd)` の入力検証**  
   `server_home.py:265` の `cmd` に allowlist 検証を追加。

5. **[P3] `core/conversation_search.py` B608 — SQL クエリの安全化**  
   f-string SQL を allowlist チェックまたは SQLAlchemy `text()` + `bindparam()` へ移行。

---

*Generated by ai-chan security bot · UTC 2026-06-09*

---
_Generated by [Claude Code](https://claude.ai/code/session_0193X9hYjSznahyQgk5AezUZ)_