### PR TITLE
[URGENT] 🚨 Security Audit 2026-06-12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ AiChan.app/
 *.app/
 
 # ── セキュリティ成果物（漏洩防止のため除外） ─────────
+# raw スキャン成果物は除外。監査レポート(*.md)は git add -f で追跡する
 logs/security/
 *.sbom.json
 bandit-report.json

--- a/logs/security/2026-06-12.md
+++ b/logs/security/2026-06-12.md
@@ -1,0 +1,153 @@
+# 🛡 Security Audit Report — 2026-06-12
+
+| Field | Value |
+|---|---|
+| **Date (UTC)** | 2026-06-12 |
+| **Commit SHA** | 40bb06e |
+| **pip-audit** | 2.10.1 |
+| **bandit** | 1.9.4 |
+| **Python** | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| pip-audit (CVEs) | 0 | 3 | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | 0 | — |
+| outdated (major) | — | — | 7 | 20 |
+
+---
+
+## 🚨 Critical / High Findings (pip-audit)
+
+| CVE ID | Package | Current Version | Fix Version |
+|---|---|---|---|
+| CVE-2026-44405 | paramiko | 3.5.1 | none available |
+| CVE-2025-69872 | diskcache | 5.6.3 | none available |
+| CVE-2025-3000 | torch | 2.12.0 | none available |
+
+> ⚠ No upstream fix versions are published yet. Monitor advisories and apply mitigations below.
+
+---
+
+## ⚠ Outdated Dependencies (major updates only)
+
+| Package | Current | Latest |
+|---|---|---|
+| cryptography | 41.0.7 | 48.0.1 |
+| launchpadlib | 1.11.0 | 2.1.0 |
+| packaging | 24.0 | 26.2 |
+| pip | 24.0 | 26.1.2 |
+| setuptools | 68.1.2 | 82.0.1 |
+| wadllib | 1.3.6 | 2.0.0 |
+| xmltodict | 0.13.0 | 1.0.4 |
+
+---
+
+## 📋 Bandit Findings (High/Medium only)
+
+| Test ID | Severity | File | Line | Description |
+|---|---|---|---|---|
+| B608 | MEDIUM | core/conversation_search.py | 306 | SQL injection via f-string query construction |
+| B608 | MEDIUM | core/conversation_search.py | 368 | SQL injection via f-string query construction |
+| B310 | MEDIUM | core/github_learner.py | 180 | urllib.urlopen — unapproved scheme risk |
+| B310 | MEDIUM | core/image_gen.py | 156 | urllib.urlopen — unapproved scheme risk |
+| B310 | MEDIUM | core/research_agent.py | 198 | urllib.urlopen — unapproved scheme risk |
+| B601 | MEDIUM | core/server_home.py | 241 | Paramiko exec_command — shell injection risk |
+| B601 | MEDIUM | core/server_home.py | 265 | Paramiko exec_command — shell injection risk |
+| B601 | MEDIUM | core/server_home.py | 298 | Paramiko exec_command — shell injection risk |
+| B601 | MEDIUM | core/server_home.py | 302 | Paramiko exec_command — shell injection risk |
+| B601 | MEDIUM | core/server_home.py | 306 | Paramiko exec_command — shell injection risk |
+| B601 | MEDIUM | core/server_home.py | 312 | Paramiko exec_command — shell injection risk |
+
+---
+
+## 🔍 Secret Scan
+
+**No secrets detected.** (Patterns: Anthropic `sk-`, GitHub `ghp_`, AWS `AKIA`, PEM private keys)
+
+---
+
+## Delta vs 前日
+
+前日レポート (`logs/security/2026-06-11.md`) が存在しないため差分比較不可。本日が初回記録。
+
+---
+
+## Recommendations
+
+1. **[P1] paramiko CVE-2026-44405** — SSH コマンド実行パスに入力検証を追加し、`exec_command()` に渡す文字列をホワイトリスト化。公式 fix リリースを監視してリリース次第アップデート。
+2. **[P1] torch CVE-2025-3000** — PyTorch の fix リリースを監視。本番では `torch` を隔離コンテナで実行し、外部入力からのモデルロード(`torch.load`)を禁止。
+3. **[P2] cryptography 41 → 48 (major)** — `cryptography` はセキュリティライブラリであり Major 更新は積極的に取り込む。ChangeLog を確認してから `pip install -U cryptography` 実施。
+4. **[P2] B608 SQL injection (conversation_search.py:306, 368)** — テーブル名・カラム名を定数またはホワイトリストから取得し、f-string での直接埋め込みを排除するか、既存 `# nosec B608` ジャスティフィケーションを明示。
+5. **[P3] diskcache CVE-2025-69872** — キャッシュデータを信頼できないユーザー入力から隔離。fix リリースまでの間、`diskcache` への書き込みを認証済みパスのみに限定。
+
+---
+
+<details>
+<summary>Raw outputs</summary>
+
+### pip-audit
+
+```
+Found 3 known vulnerabilities in 3 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+torch     2.12.0  CVE-2025-3000
+```
+
+### bandit summary
+
+```
+Total issues (by severity):
+    Undefined: 0
+    Low: 365
+    Medium: 11
+    High: 0
+Total issues (by confidence):
+    Undefined: 0
+    Low: 1
+    Medium: 10
+    High: 365
+Files skipped: 0
+Total lines of code: 54471
+```
+
+### outdated packages (all 27)
+
+| Package | Current | Latest |
+|---|---|---|
+| PyGObject | 3.48.2 | 3.56.3 |
+| PyJWT | 2.7.0 | 2.13.0 |
+| PyYAML | 6.0.1 | 6.0.3 |
+| argcomplete | 3.1.4 | 3.6.3 |
+| blinker | 1.7.0 | 1.9.0 |
+| certifi | 2026.2.25 | 2026.5.20 |
+| charset-normalizer | 3.4.6 | 3.4.7 |
+| conan | 2.27.0 | 2.29.0 |
+| cryptography | 41.0.7 | 48.0.1 |
+| dbus-python | 1.3.2 | 1.4.0 |
+| httplib2 | 0.20.4 | 0.31.2 |
+| idna | 3.11 | 3.18 |
+| launchpadlib | 1.11.0 | 2.1.0 |
+| lazr.uri | 1.0.6 | 1.0.8 |
+| oauthlib | 3.2.2 | 3.3.1 |
+| packaging | 24.0 | 26.2 |
+| patch-ng | 1.18.1 | 1.19.1 |
+| pip | 24.0 | 26.1.2 |
+| pyparsing | 3.1.1 | 3.3.2 |
+| requests | 2.33.1 | 2.34.2 |
+| setuptools | 68.1.2 | 82.0.1 |
+| six | 1.16.0 | 1.17.0 |
+| urllib3 | 2.6.3 | 2.7.0 |
+| wadllib | 1.3.6 | 2.0.0 |
+| wheel | 0.42.0 | 0.47.0 |
+| xmltodict | 0.13.0 | 1.0.4 |
+| yq | 3.1.0 | 3.4.3 |
+
+</details>


### PR DESCRIPTION
# 🛡 Security Audit Report — 2026-06-12

| Field | Value |
|---|---|
| **Date (UTC)** | 2026-06-12 |
| **Commit SHA** | 40bb06e |
| **pip-audit** | 2.10.1 |
| **bandit** | 1.9.4 |
| **Python** | 3.11.15 |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---|---|---|---|---|
| pip-audit (CVEs) | 0 | 3 | 0 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| secrets | — | — | 0 | — |
| outdated (major) | — | — | 7 | 20 |

---

## 🚨 Critical / High Findings (pip-audit)

| CVE ID | Package | Current Version | Fix Version |
|---|---|---|---|
| CVE-2026-44405 | paramiko | 3.5.1 | none available |
| CVE-2025-69872 | diskcache | 5.6.3 | none available |
| CVE-2025-3000 | torch | 2.12.0 | none available |

> ⚠ No upstream fix versions are published yet. Monitor advisories and apply mitigations below.

---

## ⚠ Outdated Dependencies (major updates only)

| Package | Current | Latest |
|---|---|---|
| cryptography | 41.0.7 | 48.0.1 |
| launchpadlib | 1.11.0 | 2.1.0 |
| packaging | 24.0 | 26.2 |
| pip | 24.0 | 26.1.2 |
| setuptools | 68.1.2 | 82.0.1 |
| wadllib | 1.3.6 | 2.0.0 |
| xmltodict | 0.13.0 | 1.0.4 |

---

## 📋 Bandit Findings (High/Medium only)

| Test ID | Severity | File | Line | Description |
|---|---|---|---|---|
| B608 | MEDIUM | core/conversation_search.py | 306 | SQL injection via f-string query construction |
| B608 | MEDIUM | core/conversation_search.py | 368 | SQL injection via f-string query construction |
| B310 | MEDIUM | core/github_learner.py | 180 | urllib.urlopen — unapproved scheme risk |
| B310 | MEDIUM | core/image_gen.py | 156 | urllib.urlopen — unapproved scheme risk |
| B310 | MEDIUM | core/research_agent.py | 198 | urllib.urlopen — unapproved scheme risk |
| B601 | MEDIUM | core/server_home.py | 241 | Paramiko exec_command — shell injection risk |
| B601 | MEDIUM | core/server_home.py | 265 | Paramiko exec_command — shell injection risk |
| B601 | MEDIUM | core/server_home.py | 298 | Paramiko exec_command — shell injection risk |
| B601 | MEDIUM | core/server_home.py | 302 | Paramiko exec_command — shell injection risk |
| B601 | MEDIUM | core/server_home.py | 306 | Paramiko exec_command — shell injection risk |
| B601 | MEDIUM | core/server_home.py | 312 | Paramiko exec_command — shell injection risk |

---

## 🔍 Secret Scan

**No secrets detected.** (Patterns: Anthropic `sk-`, GitHub `ghp_`, AWS `AKIA`, PEM private keys)

---

## Delta vs 前日

前日レポート (`logs/security/2026-06-11.md`) が存在しないため差分比較不可。本日が初回記録。

---

## Recommendations

1. **[P1] paramiko CVE-2026-44405** — SSH コマンド実行パスに入力検証を追加し、`exec_command()` に渡す文字列をホワイトリスト化。公式 fix リリースを監視してリリース次第アップデート。
2. **[P1] torch CVE-2025-3000** — PyTorch の fix リリースを監視。本番では `torch` を隔離コンテナで実行し、外部入力からのモデルロード(`torch.load`)を禁止。
3. **[P2] cryptography 41 → 48 (major)** — `cryptography` はセキュリティライブラリであり Major 更新は積極的に取り込む。ChangeLog を確認してから `pip install -U cryptography` 実施。
4. **[P2] B608 SQL injection (conversation_search.py:306, 368)** — テーブル名・カラム名を定数またはホワイトリストから取得し、f-string での直接埋め込みを排除するか、既存 `# nosec B608` ジャスティフィケーションを明示。
5. **[P3] diskcache CVE-2025-69872** — キャッシュデータを信頼できないユーザー入力から隔離。fix リリースまでの間、`diskcache` への書き込みを認証済みパスのみに限定。

---

<details>
<summary>Raw outputs</summary>

### pip-audit

```
Found 3 known vulnerabilities in 3 packages
Name      Version ID             Fix Versions
--------- ------- -------------- ------------
paramiko  3.5.1   CVE-2026-44405
diskcache 5.6.3   CVE-2025-69872
torch     2.12.0  CVE-2025-3000
```

### bandit summary

```
Total issues (by severity):
    Undefined: 0
    Low: 365
    Medium: 11
    High: 0
Total lines of code: 54471
Files skipped: 0
```

### outdated packages (all 27)

| Package | Current | Latest |
|---|---|---|
| PyGObject | 3.48.2 | 3.56.3 |
| PyJWT | 2.7.0 | 2.13.0 |
| PyYAML | 6.0.1 | 6.0.3 |
| argcomplete | 3.1.4 | 3.6.3 |
| blinker | 1.7.0 | 1.9.0 |
| certifi | 2026.2.25 | 2026.5.20 |
| charset-normalizer | 3.4.6 | 3.4.7 |
| conan | 2.27.0 | 2.29.0 |
| cryptography | 41.0.7 | 48.0.1 |
| dbus-python | 1.3.2 | 1.4.0 |
| httplib2 | 0.20.4 | 0.31.2 |
| idna | 3.11 | 3.18 |
| launchpadlib | 1.11.0 | 2.1.0 |
| lazr.uri | 1.0.6 | 1.0.8 |
| oauthlib | 3.2.2 | 3.3.1 |
| packaging | 24.0 | 26.2 |
| patch-ng | 1.18.1 | 1.19.1 |
| pip | 24.0 | 26.1.2 |
| pyparsing | 3.1.1 | 3.3.2 |
| requests | 2.33.1 | 2.34.2 |
| setuptools | 68.1.2 | 82.0.1 |
| six | 1.16.0 | 1.17.0 |
| urllib3 | 2.6.3 | 2.7.0 |
| wadllib | 1.3.6 | 2.0.0 |
| wheel | 0.42.0 | 0.47.0 |
| xmltodict | 0.13.0 | 1.0.4 |
| yq | 3.1.0 | 3.4.3 |

</details>

---
*Generated by ai-chan security bot — 2026-06-12 UTC*

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjV7s3978jb4iYPrScuGT4)_