### PR TITLE
[URGENT] 🚨 Security Audit 2026-06-21

### DIFF
--- a/logs/security/2026-06-21.md
+++ b/logs/security/2026-06-21.md
@@ -1,0 +1,176 @@
+# 🛡 Security Audit Report — 2026-06-21
+
+| Field | Value |
+|---|---|
+| Date (UTC) | 2026-06-21 |
+| Commit | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| pip-audit | 2.10.1 |
+| bandit | 1.9.4 |
+| Python | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| pip-audit | 0 | 1 | 1 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | — | 0 |
+| outdated (major) | — | — | — | 7 |
+
+---
+
+## 🚨 Critical / High Findings
+
+### CVE-2025-69872 — `diskcache` 5.6.3 · **HIGH**
+- **GHSA**: GHSA-w8v5-vhqr-4h9v
+- **Fix versions**: None published yet (upstream unfixed as of scan date)
+- **Description**: DiskCache uses Python `pickle` for serialization by default. An attacker with write access to the cache directory can achieve **arbitrary code execution** when a victim application reads from the cache.
+- **Recommendation**: Restrict filesystem permissions on the cache directory (`chmod 700`), or switch to a non-pickle serializer (e.g., `diskcache.JSONDisk`). Monitor upstream for a patched release.
+
+---
+
+## ⚠ Medium Findings (pip-audit)
+
+### CVE-2026-44405 — `paramiko` 3.5.1 · **MEDIUM**
+- **GHSA**: GHSA-r374-rxx8-8654
+- **Fix versions**: None published yet
+- **Description**: Paramiko through 4.0.0 allows the SHA-1 algorithm in RSA key operations (`rsakey.py`), which is cryptographically weak.
+- **Recommendation**: Avoid RSA keys with SHA-1 signatures in SSH connections. Prefer ed25519 or ECDSA keys. Upgrade paramiko when a fix is released.
+
+---
+
+## ⚠ Outdated Dependencies (Major Version Updates Only)
+
+| Package | Current | Latest | Notes |
+|---|---|---|---|
+| cryptography | 41.0.7 | 49.0.0 | 8 major versions behind — security-critical library |
+| setuptools | 68.1.2 | 82.0.1 | Build toolchain |
+| packaging | 24.0 | 26.2 | Build toolchain |
+| pip | 24.0 | 26.1.2 | Package manager |
+| launchpadlib | 1.11.0 | 2.1.0 | API client |
+| wadllib | 1.3.6 | 2.0.0 | WADL parser |
+| xmltodict | 0.13.0 | 1.0.4 | XML parsing |
+
+> `cryptography` is the highest-priority upgrade — it is 8 major versions behind and is a foundational security dependency used by `paramiko`, `httpx`, and others.
+
+---
+
+## 📋 Bandit Findings (Medium severity — 11 issues, High — 0)
+
+| Severity | ID | File | Line | Description |
+|---|---|---|---|---|
+| MEDIUM | B608 | `core/conversation_search.py` | 306 | Possible SQL injection via f-string query construction |
+| MEDIUM | B608 | `core/conversation_search.py` | 368 | Possible SQL injection via f-string query construction |
+| MEDIUM | B310 | `core/github_learner.py` | 180 | `urllib.request.urlopen` — permits `file:/` scheme |
+| MEDIUM | B310 | `core/image_gen.py` | 156 | `urllib.request.urlopen` — permits `file:/` scheme |
+| MEDIUM | B310 | `core/research_agent.py` | 198 | `urllib.request.urlopen` — permits `file:/` scheme |
+| MEDIUM | B601 | `core/server_home.py` | 241 | Paramiko `exec_command` — possible shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 265 | Paramiko `exec_command` — possible shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 298 | Paramiko `exec_command` — possible shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 302 | Paramiko `exec_command` — possible shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 306 | Paramiko `exec_command` — possible shell injection |
+| MEDIUM | B601 | `core/server_home.py` | 312 | Paramiko `exec_command` — possible shell injection |
+
+> 365 LOW-severity issues (mostly style/informational) not listed here per policy (Medium+ only).
+
+---
+
+## 🔍 Secret Scan
+
+**No secrets detected.** Pattern scan (Anthropic keys `sk-*`, GitHub PATs `ghp_*`, AWS keys `AKIA*`, PEM private keys) across all `.py` / `.json` / `.yaml` / `.yml` files returned 0 matches.
+
+---
+
+## Delta vs Previous Day
+
+No previous report found (`logs/security/2026-06-20.md` does not exist). This is the **first audit run** — no delta available.
+
+---
+
+## Recommendations (Priority Order)
+
+1. **[HIGH] Mitigate diskcache RCE (CVE-2025-69872)**: Immediately restrict cache directory permissions (`chmod 700 <cache_dir>`) and switch to `JSONDisk` or another non-pickle backend. This is the most critical finding — exploitable by any process with local write access.
+
+2. **[HIGH] Upgrade `cryptography` from 41.x → 49.x**: This library is 8 major versions behind and underpins `paramiko`, `httpx`, and TLS handling. Run `pip install -U cryptography` and validate against the test suite.
+
+3. **[MEDIUM] Address paramiko SHA-1 (CVE-2026-44405)**: Rotate SSH keys to ed25519/ECDSA; add `preferred_algorithms` config to exclude `rsa-sha1`. Upgrade when a fixed paramiko release is available.
+
+4. **[MEDIUM] Review B608 SQL injection in `core/conversation_search.py`**: Lines 306 and 368 use f-strings in SQL queries. Audit that all interpolated values (table/column names) are whitelisted constants, not user input. Consider parameterized query helpers even for structural identifiers.
+
+5. **[LOW] Audit B601 Paramiko `exec_command` calls in `core/server_home.py`**: Verify that commands sent via SSH (lines 241, 265, 298, 302, 306, 312) are hardcoded constants or validated against an allowlist before execution. No immediate exploit path identified, but shell injection via Paramiko is high-impact if user input reaches these calls.
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### bandit summary
+
+```
+Run started:2026-06-21 00:05:15.551888+00:00
+
+Run metrics:
+  Total lines of code: 54471
+  Total lines skipped (#nosec): 0
+  Total potential issues skipped (specifically disabled): 10
+
+Total issues (by severity):
+  Undefined: 0
+  Low: 365
+  Medium: 11
+  High: 0
+
+Total issues (by confidence):
+  Undefined: 0
+  Low: 1
+  Medium: 10
+  High: 365
+```
+
+### outdated packages (pip list --outdated)
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.6.17 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.29.1    wheel
+cryptography       41.0.7    49.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.18      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.2    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.13.0    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+requests           2.33.1    2.34.2    wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+</details>


### PR DESCRIPTION
# 🛡 Security Audit Report — 2026-06-21

| Field | Value |
|---|---|
| Date (UTC) | 2026-06-21 |
| Commit | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
| pip-audit | 2.10.1 |
| bandit | 1.9.4 |
| Python | 3.11.15 |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---|---|---|---|---|
| pip-audit | 0 | 1 | 1 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| secrets | — | — | — | 0 |
| outdated (major) | — | — | — | 7 |

---

## 🚨 Critical / High Findings

### CVE-2025-69872 — `diskcache` 5.6.3 · **HIGH**
- **GHSA**: GHSA-w8v5-vhqr-4h9v
- **Fix versions**: None published yet (upstream unfixed as of scan date)
- **Description**: DiskCache uses Python `pickle` for serialization by default. An attacker with write access to the cache directory can achieve **arbitrary code execution** when a victim application reads from the cache.
- **Recommendation**: Restrict filesystem permissions on the cache directory (`chmod 700`), or switch to a non-pickle serializer (e.g., `diskcache.JSONDisk`). Monitor upstream for a patched release.

---

## ⚠ Medium Findings (pip-audit)

### CVE-2026-44405 — `paramiko` 3.5.1 · **MEDIUM**
- **GHSA**: GHSA-r374-rxx8-8654
- **Fix versions**: None published yet
- **Description**: Paramiko through 4.0.0 allows the SHA-1 algorithm in RSA key operations (`rsakey.py`), which is cryptographically weak.
- **Recommendation**: Avoid RSA keys with SHA-1 signatures in SSH connections. Prefer ed25519 or ECDSA keys. Upgrade paramiko when a fix is released.

---

## ⚠ Outdated Dependencies (Major Version Updates Only)

| Package | Current | Latest | Notes |
|---|---|---|---|
| cryptography | 41.0.7 | 49.0.0 | 8 major versions behind — security-critical library |
| setuptools | 68.1.2 | 82.0.1 | Build toolchain |
| packaging | 24.0 | 26.2 | Build toolchain |
| pip | 24.0 | 26.1.2 | Package manager |
| launchpadlib | 1.11.0 | 2.1.0 | API client |
| wadllib | 1.3.6 | 2.0.0 | WADL parser |
| xmltodict | 0.13.0 | 1.0.4 | XML parsing |

> `cryptography` is the highest-priority upgrade — it is 8 major versions behind and is a foundational security dependency used by `paramiko`, `httpx`, and others.

---

## 📋 Bandit Findings (Medium severity — 11 issues, High — 0)

| Severity | ID | File | Line | Description |
|---|---|---|---|---|
| MEDIUM | B608 | `core/conversation_search.py` | 306 | Possible SQL injection via f-string query construction |
| MEDIUM | B608 | `core/conversation_search.py` | 368 | Possible SQL injection via f-string query construction |
| MEDIUM | B310 | `core/github_learner.py` | 180 | `urllib.request.urlopen` — permits `file:/` scheme |
| MEDIUM | B310 | `core/image_gen.py` | 156 | `urllib.request.urlopen` — permits `file:/` scheme |
| MEDIUM | B310 | `core/research_agent.py` | 198 | `urllib.request.urlopen` — permits `file:/` scheme |
| MEDIUM | B601 | `core/server_home.py` | 241 | Paramiko `exec_command` — possible shell injection |
| MEDIUM | B601 | `core/server_home.py` | 265 | Paramiko `exec_command` — possible shell injection |
| MEDIUM | B601 | `core/server_home.py` | 298 | Paramiko `exec_command` — possible shell injection |
| MEDIUM | B601 | `core/server_home.py` | 302 | Paramiko `exec_command` — possible shell injection |
| MEDIUM | B601 | `core/server_home.py` | 306 | Paramiko `exec_command` — possible shell injection |
| MEDIUM | B601 | `core/server_home.py` | 312 | Paramiko `exec_command` — possible shell injection |

---

## 🔍 Secret Scan

**No secrets detected.**

---

## Recommendations (Priority Order)

1. **[HIGH] Mitigate diskcache RCE (CVE-2025-69872)**: `chmod 700 <cache_dir>` + switch to `JSONDisk`.
2. **[HIGH] Upgrade `cryptography` 41.x → 49.x**: 8 major versions behind; foundational security dep.
3. **[MEDIUM] Address paramiko SHA-1 (CVE-2026-44405)**: Rotate to ed25519/ECDSA keys.
4. **[MEDIUM] Review B608 SQL injection** in `core/conversation_search.py:306,368`.
5. **[LOW] Audit B601 Paramiko `exec_command`** in `core/server_home.py` — validate all cmd inputs.

---

*Generated by ai-chan security bot · 2026-06-21 UTC*

---
_Generated by [Claude Code](https://claude.ai/code/session_018uJ3GqKomv8HXs8xR4nm7E)_