### PR TITLE
[URGENT] 🚨 Security Audit 2026-06-24

### DIFF
--- a/logs/security/2026-06-24.md
+++ b/logs/security/2026-06-24.md
@@ -1,0 +1,245 @@
+# Security Audit Report — 2026-06-24
+
+| Field | Value |
+|---|---|
+| Date (UTC) | 2026-06-24 |
+| Commit | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| pip-audit | 2.10.1 |
+| bandit | 1.9.4 |
+| Python | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---|---|---|---|---|
+| pip-audit (CVE) | 0 | 1 | 1 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | — | 0 |
+| outdated (major) | — | — | — | 7 |
+
+> `diskcache` CVE-2025-69872 は pickle による任意コード実行のため HIGH 扱いとする。  
+> `paramiko` CVE-2026-44405 は SHA-1 アルゴリズム許可による暗号強度低下のため MEDIUM 扱い。
+
+---
+
+## 🚨 Critical / High Findings
+
+### CVE-2025-69872 — diskcache 5.6.3 (HIGH)
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2025-69872 |
+| GHSA | GHSA-w8v5-vhqr-4h9v |
+| Package | diskcache 5.6.3 |
+| Fix Version | **修正版なし (upstream 未パッチ)** |
+| Description | DiskCache はデフォルトで Python pickle を使用してシリアライズを行う。攻撃者がキャッシュディレクトリへの書き込みアクセスを取得した場合、被害者アプリがキャッシュを読み取った際に任意コードを実行できる。 |
+| Mitigation | キャッシュディレクトリのパーミッション強化 (`chmod 700`)、または diskcache を使用しているコードを安全な代替 (sqlite / redis) に移行するまでの暫定対処 |
+
+---
+
+## ⚠ Vulnerable Dependencies (MEDIUM)
+
+### CVE-2026-44405 — paramiko 3.5.1 (MEDIUM)
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2026-44405 |
+| GHSA | GHSA-r374-rxx8-8654 |
+| Package | paramiko 3.5.1 |
+| Fix Version | **修正版なし (upstream: commit a448945 を待機中)** |
+| Description | Paramiko 4.0.0 以前で SHA-1 アルゴリズムが許可されている。ダウングレード攻撃や中間者攻撃が理論上可能。 |
+| Mitigation | SSH 接続設定で SHA-1 ベースの鍵交換・ホスト鍵アルゴリズムを明示的に無効化。修正版リリースを監視し速やかにアップグレード。 |
+
+---
+
+## ⚠ Outdated Dependencies (メジャー更新のみ)
+
+| Package | Installed | Latest | Notes |
+|---|---|---|---|
+| cryptography | 41.0.7 | 49.0.0 | システム Python 環境 (pip 要件とは別) |
+| setuptools | 68.1.2 | 82.0.1 | システム Python 環境 |
+| packaging | 24.0 | 26.2 | システム Python 環境 |
+| pip | 24.0 | 26.1.2 | システム Python 環境 |
+| xmltodict | 0.13.0 | 1.0.4 | システム Python 環境 |
+| launchpadlib | 1.11.0 | 2.1.0 | システム Python 環境 |
+| wadllib | 1.3.6 | 2.0.0 | システム Python 環境 |
+
+> 注: これらは `pip list --outdated` によるシステム Python 環境との比較。  
+> `requirements.txt` で管理されているパッケージ (pip_audit.json 参照) とは独立した環境。
+
+---
+
+## 📋 Bandit Findings (High/Medium のみ)
+
+### B608 — Possible SQL Injection (MEDIUM × 2)
+
+| # | File | Line | Issue |
+|---|---|---|---|
+| 1 | `core/conversation_search.py` | 306 | f-string による SQL 文字列構築 — テーブル名・カラム名を変数で展開 |
+| 2 | `core/conversation_search.py` | 368 | f-string による SQL 文字列構築 — JOIN/WHERE/LIMIT に変数展開 |
+
+> 両者ともテーブル名・カラム名は内部ホワイトリストから来ている可能性があるが、明示的な検証が確認できないためフラグ。
+
+### B310 — urllib.request.urlopen (MEDIUM × 3)
+
+| # | File | Line | Issue |
+|---|---|---|---|
+| 1 | `core/github_learner.py` | 180 | urlopen でカスタムスキーム (`file:/` 等) が許可される可能性 |
+| 2 | `core/image_gen.py` | 156 | urlopen でカスタムスキーム許可の可能性 |
+| 3 | `core/research_agent.py` | 198 | urlopen でカスタムスキーム許可の可能性 |
+
+> 各箇所に `# noqa: S310` が付与されており、意図的な使用と確認済みの可能性あり。入力値の URL スキーム検証 (`https://` のみ許可) を明示的に実装することを推奨。
+
+### B601 — Paramiko exec_command (MEDIUM × 6)
+
+| # | File | Line | Issue |
+|---|---|---|---|
+| 1 | `core/server_home.py` | 241 | `exec_command("echo ok")` — リテラルのみ、低リスク |
+| 2 | `core/server_home.py` | 265 | `exec_command(cmd, ...)` — `cmd` の出所・サニタイズを要確認 |
+| 3 | `core/server_home.py` | 298 | `exec_command("uptime -p")` — リテラル、低リスク |
+| 4 | `core/server_home.py` | 302 | `exec_command("df -h / | tail -1")` — リテラル、低リスク |
+| 5 | `core/server_home.py` | 306 | `exec_command("free -h | ...")` — リテラル、低リスク |
+| 6 | `core/server_home.py` | 312 | `exec_command("docker ps ...")` — リテラル、低リスク |
+
+> Line 265 の `cmd` 変数が外部入力を含む場合は **シェルインジェクション** のリスクあり。優先的に確認。
+
+---
+
+## 🔍 Secret Scan
+
+シークレット漏洩 **0 件** — 対象パターン (OpenAI key, GitHub PAT, AWS AKIA, Private key) は検出されませんでした。
+
+---
+
+## Delta vs 前日
+
+前日ログ `logs/security/2026-06-23.md` は存在しないため差分比較不可 (初回または前日スキップ)。
+
+---
+
+## Recommendations (優先度順)
+
+1. **[HIGH / 即時]** `diskcache` のキャッシュディレクトリパーミッションを `chmod 700` に設定し、不正書き込みアクセスを遮断する。CVE-2025-69872 の修正版リリースを週次で監視し、リリース次第アップグレード。
+2. **[HIGH / 即時]** `core/server_home.py:265` の `cmd` 変数の出所を確認。外部・ユーザー入力が混入する場合は許可コマンドのホワイトリスト検証を実装。
+3. **[MEDIUM / 今スプリント]** `paramiko` の SSH 接続設定で `disabled_algorithms` を使用し SHA-1 系アルゴリズムを明示的に無効化。アップストリームパッチをウォッチ。
+4. **[MEDIUM / 今スプリント]** `core/conversation_search.py:306,368` の SQL 文字列構築をパラメータ化クエリまたは安全な識別子エスケープに変更。テーブル名・カラム名はホワイトリストで検証。
+5. **[LOW / 次スプリント]** `core/github_learner.py`, `core/image_gen.py`, `core/research_agent.py` の `urlopen` 呼び出しに URL スキーム検証 (`assert url.startswith("https://")`) を追加し `# noqa` を外す。
+
+---
+
+<details>
+<summary>Raw outputs</summary>
+
+### pip-audit
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### bandit (Medium/High のみ抜粋)
+
+```
+>> Issue: [B608:hardcoded_sql_expressions] Possible SQL injection vector through string-based query construction.
+   Severity: Medium   Confidence: Medium
+   CWE: CWE-89
+   Location: core/conversation_search.py:306:24
+
+>> Issue: [B608:hardcoded_sql_expressions] Possible SQL injection vector through string-based query construction.
+   Severity: Medium   Confidence: Low
+   CWE: CWE-89
+   Location: core/conversation_search.py:368:12
+
+>> Issue: [B310:blacklist] Audit url open for permitted schemes.
+   Severity: Medium   Confidence: High
+   CWE: CWE-22
+   Location: core/github_learner.py:180:17
+
+>> Issue: [B310:blacklist] Audit url open for permitted schemes.
+   Severity: Medium   Confidence: High
+   CWE: CWE-22
+   Location: core/image_gen.py:156:13
+
+>> Issue: [B310:blacklist] Audit url open for permitted schemes.
+   Severity: Medium   Confidence: High
+   CWE: CWE-22
+   Location: core/research_agent.py:198:17
+
+>> Issue: [B601:paramiko_calls] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium
+   CWE: CWE-78
+   Location: core/server_home.py:241:16
+
+>> Issue: [B601:paramiko_calls] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium
+   CWE: CWE-78
+   Location: core/server_home.py:265:40
+
+>> Issue: [B601:paramiko_calls] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium
+   CWE: CWE-78
+   Location: core/server_home.py:298:28
+
+>> Issue: [B601:paramiko_calls] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium
+   CWE: CWE-78
+   Location: core/server_home.py:302:28
+
+>> Issue: [B601:paramiko_calls] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium
+   CWE: CWE-78
+   Location: core/server_home.py:306:28
+
+>> Issue: [B601:paramiko_calls] Possible shell injection via Paramiko call.
+   Severity: Medium   Confidence: Medium
+   CWE: CWE-78
+   Location: core/server_home.py:312:28
+
+Run metrics:
+  Total issues (by severity):
+    Low: 365
+    Medium: 11
+    High: 0
+  Total lines of code: 54471
+```
+
+### pip list --outdated
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.6.17 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.29.1    wheel
+cryptography       41.0.7    49.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.31.2    wheel
+idna               3.11      3.18      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.2    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.13.0    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+requests           2.33.1    2.34.2    wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+</details>


### PR DESCRIPTION
# Security Audit Report — 2026-06-24

| Field | Value |
|---|---|
| Date (UTC) | 2026-06-24 |
| Commit | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
| pip-audit | 2.10.1 |
| bandit | 1.9.4 |
| Python | 3.11.15 |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---|---|---|---|---|
| pip-audit (CVE) | 0 | 1 | 1 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| secrets | — | — | — | 0 |
| outdated (major) | — | — | — | 7 |

> `diskcache` CVE-2025-69872 は pickle による任意コード実行のため HIGH 扱い。  
> `paramiko` CVE-2026-44405 は SHA-1 アルゴリズム許可による暗号強度低下のため MEDIUM 扱い。

---

## 🚨 Critical / High Findings

### CVE-2025-69872 — diskcache 5.6.3 (HIGH)

| Field | Value |
|---|---|
| CVE | CVE-2025-69872 |
| GHSA | GHSA-w8v5-vhqr-4h9v |
| Package | diskcache 5.6.3 |
| Fix Version | **修正版なし (upstream 未パッチ)** |
| Description | DiskCache はデフォルトで Python pickle を使用してシリアライズを行う。攻撃者がキャッシュディレクトリへの書き込みアクセスを取得した場合、被害者アプリがキャッシュを読み取った際に任意コードを実行できる。 |
| Mitigation | キャッシュディレクトリのパーミッション強化 (`chmod 700`)、または diskcache を使用しているコードを安全な代替 (sqlite / redis) に移行するまでの暫定対処 |

---

## ⚠ Vulnerable Dependencies (MEDIUM)

### CVE-2026-44405 — paramiko 3.5.1 (MEDIUM)

| Field | Value |
|---|---|
| CVE | CVE-2026-44405 |
| GHSA | GHSA-r374-rxx8-8654 |
| Package | paramiko 3.5.1 |
| Fix Version | **修正版なし (upstream: commit a448945 を待機中)** |
| Description | Paramiko 4.0.0 以前で SHA-1 アルゴリズムが許可されている。ダウングレード攻撃や中間者攻撃が理論上可能。 |
| Mitigation | SSH 接続設定で SHA-1 ベースの鍵交換・ホスト鍵アルゴリズムを明示的に無効化。修正版リリースを監視し速やかにアップグレード。 |

---

## 📋 Bandit Findings (High/Medium のみ)

### B608 — Possible SQL Injection (MEDIUM × 2)

| # | File | Line | Issue |
|---|---|---|---|
| 1 | `core/conversation_search.py` | 306 | f-string による SQL 文字列構築 |
| 2 | `core/conversation_search.py` | 368 | f-string による SQL 文字列構築 |

### B310 — urllib.request.urlopen (MEDIUM × 3)

| # | File | Line | Issue |
|---|---|---|---|
| 1 | `core/github_learner.py` | 180 | urlopen でカスタムスキーム許可の可能性 |
| 2 | `core/image_gen.py` | 156 | urlopen でカスタムスキーム許可の可能性 |
| 3 | `core/research_agent.py` | 198 | urlopen でカスタムスキーム許可の可能性 |

### B601 — Paramiko exec_command (MEDIUM × 6)

| # | File | Line | Issue |
|---|---|---|---|
| 1 | `core/server_home.py` | 241 | `exec_command("echo ok")` — リテラル |
| 2 | `core/server_home.py` | 265 | `exec_command(cmd, ...)` — **要確認** |
| 3–6 | `core/server_home.py` | 298,302,306,312 | リテラルコマンド、低リスク |

---

## 🔍 Secret Scan

シークレット漏洩 **0 件**

---

## Recommendations (優先度順)

1. **[HIGH / 即時]** `diskcache` キャッシュディレクトリを `chmod 700` で保護。CVE-2025-69872 の修正版を週次監視。
2. **[HIGH / 即時]** `core/server_home.py:265` の `cmd` 変数の出所を確認。外部入力が混入する場合はホワイトリスト検証を実装。
3. **[MEDIUM / 今スプリント]** `paramiko` の `disabled_algorithms` で SHA-1 を明示的に無効化。
4. **[MEDIUM / 今スプリント]** `core/conversation_search.py:306,368` の SQL 構築をパラメータ化クエリに変更。
5. **[LOW / 次スプリント]** `urlopen` 呼び出しに URL スキーム検証を追加。

---

*自動生成: ai-chan security bot | pip-audit 2.10.1 | bandit 1.9.4*

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpmEYKT9JX5zuv5SQyc9YA)_