### PR TITLE
[URGENT] 🚨 Security Audit 2026-06-30

### DIFF
--- a/logs/security/2026-06-30.md
+++ b/logs/security/2026-06-30.md
@@ -1,0 +1,202 @@
+# 🛡 Security Audit Report — 2026-06-30
+
+| Item | Value |
+|------|-------|
+| **Date (UTC)** | 2026-06-30 |
+| **Commit SHA** | 40bb06efeb35b72f5823fd6a27c9db2ad49f896c |
+| **pip-audit** | 2.10.1 |
+| **bandit** | 1.9.4 |
+| **Python** | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---------|----------|------|--------|-----|
+| pip-audit | 0 | 2 | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | 0 | — |
+| outdated (major) | — | — | — | 7 |
+
+> **Total actionable findings: 2 HIGH CVEs + 11 Medium bandit issues**
+
+---
+
+## 🚨 Critical / High Findings (pip-audit)
+
+### CVE-2025-69872 — diskcache 5.6.3 (HIGH · RCE)
+
+| Field | Value |
+|-------|-------|
+| Package | `diskcache` 5.6.3 |
+| CVE | CVE-2025-69872 |
+| Fix Version | No upstream fix released yet |
+| CVSS | High (RCE) |
+
+**Description:** DiskCache through 5.6.3 uses Python `pickle` for serialization by default. An attacker with write access to the cache directory can achieve **arbitrary code execution** when a victim application reads from the cache.
+
+**Remediation:** Until an upstream patch is available:
+- Restrict filesystem permissions on the cache directory to the application user only (`chmod 700`)
+- Consider switching to a non-pickle serializer (e.g., JSON) if diskcache supports it in your usage
+- Monitor for upstream advisory / patch release
+
+---
+
+### CVE-2026-44405 — paramiko 3.5.1 (HIGH · Cryptographic Weakness)
+
+| Field | Value |
+|-------|-------|
+| Package | `paramiko` 3.5.1 |
+| CVE | CVE-2026-44405 |
+| GHSA | GHSA-r374-rxx8-8654 |
+| Fix Version | No official fix release yet (patch commit: a448945) |
+
+**Description:** Paramiko through 4.0.0 before commit `a448945` allows the SHA-1 algorithm in `rsakey.py`. SHA-1 is cryptographically weak and deprecated for digital signatures; exploitation enables signature forgery attacks against RSA host key verification.
+
+**Remediation:**
+- Pin paramiko to a build that includes commit `a448945` once released, or apply patch manually
+- Enforce `PreferredAuthentications` to exclude RSA-SHA1 where possible
+- Consider migrating SSH key usage to Ed25519
+
+---
+
+## ⚠ Outdated Dependencies (Major Version Bumps)
+
+| Package | Installed | Latest | Gap |
+|---------|-----------|--------|-----|
+| `cryptography` | 41.0.7 | 49.0.0 | +8 major |
+| `setuptools` | 68.1.2 | 82.0.1 | +14 major |
+| `packaging` | 24.0 | 26.2 | +2 major |
+| `pip` | 24.0 | 26.1.2 | +2 major |
+| `launchpadlib` | 1.11.0 | 2.1.0 | +1 major |
+| `wadllib` | 1.3.6 | 2.0.0 | +1 major |
+| `xmltodict` | 0.13.0 | 1.0.4 | +1 major |
+
+> `cryptography` 41 → 49 is particularly notable — 8 major versions behind includes multiple security patches.
+
+---
+
+## 📋 Bandit Findings (Medium only — 11 issues, 0 High)
+
+| # | Test ID | Severity | Confidence | File | Line | Issue |
+|---|---------|----------|------------|------|------|-------|
+| 1 | B608 | MEDIUM | MEDIUM | `core/conversation_search.py` | 306 | SQL injection via f-string query construction |
+| 2 | B608 | MEDIUM | LOW | `core/conversation_search.py` | 368 | SQL injection via f-string query construction |
+| 3 | B310 | MEDIUM | HIGH | `core/github_learner.py` | 180 | `urllib.request.urlopen` — file:/ scheme risk |
+| 4 | B310 | MEDIUM | HIGH | `core/image_gen.py` | 156 | `urllib.request.urlopen` — file:/ scheme risk |
+| 5 | B310 | MEDIUM | HIGH | `core/research_agent.py` | 198 | `urllib.request.urlopen` — file:/ scheme risk |
+| 6 | B601 | MEDIUM | MEDIUM | `core/server_home.py` | 241 | Paramiko `exec_command` — potential shell injection |
+| 7 | B601 | MEDIUM | MEDIUM | `core/server_home.py` | 265 | Paramiko `exec_command` — potential shell injection |
+| 8 | B601 | MEDIUM | MEDIUM | `core/server_home.py` | 298 | Paramiko `exec_command` — potential shell injection |
+| 9 | B601 | MEDIUM | MEDIUM | `core/server_home.py` | 302 | Paramiko `exec_command` — potential shell injection |
+| 10 | B601 | MEDIUM | MEDIUM | `core/server_home.py` | 306 | Paramiko `exec_command` — potential shell injection |
+| 11 | B601 | MEDIUM | MEDIUM | `core/server_home.py` | 312 | Paramiko `exec_command` — potential shell injection |
+
+**Notes:**
+- B608 (SQL injection): f-string SQL in `conversation_search.py` uses column/table names from internal config, not user input — low exploitability, but warrants review for completeness
+- B310 (URL open): All three sites already use `# noqa: S310` annotations indicating intentional, reviewed usage
+- B601 (Paramiko): `exec_command` calls in `server_home.py` — hardcoded system commands (`uptime`, `df`, `free`, `docker ps`) are not user-controlled; only `cmd` at line 265 may accept variable input and should be reviewed
+
+---
+
+## 🔍 Secret Scan
+
+**No secrets detected.** Patterns scanned: `sk-*`, `ghp_*`, `AKIA*`, `-----BEGIN * PRIVATE KEY-----`
+
+---
+
+## Delta vs 前日
+
+前日レポート (`logs/security/2026-06-29.md`) は存在しないため差分比較はスキップ。  
+(初回実行または前日ファイル未コミット)
+
+---
+
+## Recommendations (優先度順)
+
+1. **[P1] diskcache CVE-2025-69872 緩和** — キャッシュディレクトリのパーミッション制限 (`chmod 700`) を即時適用。upstream patch リリースを監視し、出次第 `requirements.txt` を更新する。
+2. **[P1] paramiko CVE-2026-44405 緩和** — SSH 接続で SHA-1 RSA を避ける設定を確認。paramiko のパッチ版リリース (`a448945` 含む) を追跡し、`requirements.txt` を固定バージョンで更新する。
+3. **[P2] cryptography を最新メジャー (49.x) へ更新** — 8メジャーバージョン差はセキュリティリグレッションリスクが高い。`pip install --upgrade cryptography` で更新し、互換性テストを実施する。
+4. **[P3] `core/server_home.py:265` の `cmd` 入力検証** — `exec_command(cmd, ...)` の `cmd` 変数が外部入力を受け入れる可能性を確認し、許可リスト方式に変更するか、入力をサニタイズする。
+5. **[P3] pip-audit を CI/CD パイプラインに組み込む** — 現在 daily cron のみ。PR ごとにも実行することで newly introduced CVEs を早期検出できる。
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### outdated packages (full list)
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.6.3     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.6.17 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.30.0    wheel
+cryptography       41.0.7    49.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.32.0    wheel
+idna               3.11      3.18      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.2    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.13.0    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+requests           2.33.1    2.34.2    wheel
+setuptools         68.1.2    82.0.1    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.0.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     3.4.3     wheel
+```
+
+### bandit (full text)
+
+```
+Run started:2026-06-30 00:03:24
+
+Code scanned:
+  Total lines of code: 54471
+  Total lines skipped (#nosec): 0
+  Total potential issues skipped (nosec BXXX): 10
+
+Run metrics:
+  Total issues (by severity):
+    Undefined: 0 / Low: 365 / Medium: 11 / High: 0
+  Total issues (by confidence):
+    Undefined: 0 / Low: 1 / Medium: 10 / High: 365
+
+Issue [B608] core/conversation_search.py:306 - SQL injection (MEDIUM/MEDIUM)
+Issue [B608] core/conversation_search.py:368 - SQL injection (MEDIUM/LOW)
+Issue [B310] core/github_learner.py:180   - urlopen scheme (MEDIUM/HIGH)
+Issue [B310] core/image_gen.py:156        - urlopen scheme (MEDIUM/HIGH)
+Issue [B310] core/research_agent.py:198   - urlopen scheme (MEDIUM/HIGH)
+Issue [B601] core/server_home.py:241      - paramiko exec_command (MEDIUM/MEDIUM)
+Issue [B601] core/server_home.py:265      - paramiko exec_command (MEDIUM/MEDIUM)
+Issue [B601] core/server_home.py:298      - paramiko exec_command (MEDIUM/MEDIUM)
+Issue [B601] core/server_home.py:302      - paramiko exec_command (MEDIUM/MEDIUM)
+Issue [B601] core/server_home.py:306      - paramiko exec_command (MEDIUM/MEDIUM)
+Issue [B601] core/server_home.py:312      - paramiko exec_command (MEDIUM/MEDIUM)
+```
+
+</details>


### PR DESCRIPTION
# 🛡 Daily Security Audit — 2026-06-30

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---------|----------|------|--------|-----|
| pip-audit | 0 | **2** | 0 | 0 |
| bandit | 0 | 0 | **11** | 365 |
| secrets | — | — | **0** | — |
| outdated (major) | — | — | — | **7** |

## 🚨 HIGH CVEs Requiring Immediate Attention

### CVE-2025-69872 — `diskcache` 5.6.3 (RCE via Pickle Deserialization)
DiskCache uses Python `pickle` by default. An attacker with write access to the cache directory can achieve **arbitrary code execution**. No upstream fix yet — restrict cache dir permissions to `chmod 700` immediately.

### CVE-2026-44405 — `paramiko` 3.5.1 (SHA-1 Algorithm Allowed)
Paramiko allows the deprecated SHA-1 algorithm in RSA key handling (`rsakey.py`). Enables signature forgery. No official release with patch yet (commit `a448945`). Avoid RSA-SHA1 in SSH config; track upstream for patched release.

## ⚠ Notable Outdated Packages (Major Bumps)

| Package | Installed | Latest |
|---------|-----------|--------|
| `cryptography` | 41.0.7 | 49.0.0 (+8 major) |
| `setuptools` | 68.1.2 | 82.0.1 |
| `packaging` | 24.0 | 26.2 |
| `launchpadlib` | 1.11.0 | 2.1.0 |
| `wadllib` | 1.3.6 | 2.0.0 |
| `xmltodict` | 0.13.0 | 1.0.4 |

## 📋 Bandit Findings (Medium × 11, High × 0)

- **B608** SQL injection vectors: `core/conversation_search.py:306`, `:368`
- **B310** urlopen scheme risk: `core/github_learner.py:180`, `core/image_gen.py:156`, `core/research_agent.py:198`
- **B601** Paramiko exec_command: `core/server_home.py:241,265,298,302,306,312`

## 🔍 Secret Scan

No secrets detected.

## Recommendations (Priority Order)

1. **[P1]** Restrict diskcache cache directory permissions (`chmod 700`) — RCE mitigation
2. **[P1]** Monitor paramiko upstream for patch release (commit `a448945`)
3. **[P2]** Upgrade `cryptography` from 41.0.7 → 49.x (8 major versions of security fixes)
4. **[P3]** Audit `core/server_home.py:265` — ensure `cmd` variable cannot be user-controlled
5. **[P3]** Add `pip-audit` to per-PR CI pipeline for early CVE detection

---
Full report: [`logs/security/2026-06-30.md`](logs/security/2026-06-30.md)
Relates to: #133

🤖 Generated by ai-chan security bot (automated daily audit)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8D5ZZQqLkHccCz3HndqME)_