### PR TITLE
[URGENT] 🚨 Security Audit 2026-07-06

### DIFF
--- a/logs/security/2026-07-06.md
+++ b/logs/security/2026-07-06.md
@@ -1,0 +1,164 @@
+# 🛡 Security Audit Report — 2026-07-06
+
+| Item | Value |
+|------|-------|
+| Date (UTC) | 2026-07-06 |
+| Commit SHA | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
+| pip-audit | 2.10.1 |
+| bandit | 1.9.4 |
+| Python | 3.11.15 |
+
+---
+
+## Summary
+
+| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
+|---------|----------|------|--------|-----|
+| pip-audit | 0 | 2 | 0 | 0 |
+| bandit | 0 | 0 | 11 | 365 |
+| secrets | — | — | 0 | — |
+| outdated (major) | — | — | — | 8 |
+
+---
+
+## 🚨 Critical / High Findings
+
+### pip-audit — Known Vulnerabilities
+
+| CVE | Package | Installed | Fix Version | Description |
+|-----|---------|-----------|-------------|-------------|
+| CVE-2026-44405 | paramiko | 3.5.1 | *(none upstream)* | In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm — cryptographic weakness enabling downgrade attacks |
+| CVE-2025-69872 | diskcache | 5.6.3 | *(none upstream)* | DiskCache uses Python pickle for serialization by default; attacker with write access to cache directory achieves arbitrary code execution. **Note:** `_secure_cache_dir()` mitigation applied locally (see requirements.txt comment 2026-04-22). |
+
+> ⚠ **paramiko CVE-2026-44405** has no upstream fix version. The library is pinned to 3.x in requirements.txt pending API diff validation; consider patching to commit a448945 or disabling RSA/SHA-1 key types in SSH client config.
+
+---
+
+## ⚠ Outdated Dependencies (Major Version Bumps)
+
+| Package | Installed | Latest | Delta |
+|---------|-----------|--------|-------|
+| cryptography | 41.0.7 | 49.0.0 | +8 major (system pip; requirements.txt pins >=46.0.7, installed=49.0.0 ✓) |
+| setuptools | 68.1.2 | 83.0.0 | +15 major (system pip) |
+| packaging | 24.0 | 26.2 | +2 major (system pip) |
+| pip | 24.0 | 26.1.2 | +2 major (system pip) |
+| launchpadlib | 1.11.0 | 2.1.0 | +1 major (system pip) |
+| wadllib | 1.3.6 | 2.1.0 | +1 major (system pip) |
+| xmltodict | 0.13.0 | 1.0.4 | 0→1 major (system pip) |
+| yq | 3.1.0 | 4.1.1 | +1 major (system pip) |
+
+> All above are system-pip packages not declared in `requirements.txt` (or already satisfied at higher version via requirements install). No action required for in-project dependencies.
+
+---
+
+## 📋 Bandit Findings (High/Medium only)
+
+| Severity | Confidence | Issue ID | File | Line | Description |
+|----------|------------|----------|------|------|-------------|
+| Medium | Medium | B608 | `core/conversation_search.py` | 306 | Possible SQL injection via f-string query construction |
+| Medium | Low | B608 | `core/conversation_search.py` | 368 | Possible SQL injection via string-based query construction |
+| Medium | High | B310 | `core/github_learner.py` | 180 | `urllib.request.urlopen` — audit URL scheme (file:/ risk) |
+| Medium | High | B310 | `core/image_gen.py` | 156 | `urllib.request.urlopen` — audit URL scheme (file:/ risk) |
+| Medium | High | B310 | `core/research_agent.py` | 198 | `urllib.request.urlopen` — audit URL scheme (file:/ risk) |
+| Medium | Medium | B601 | `core/server_home.py` | 241 | Paramiko `exec_command` — possible shell injection if input unsanitized |
+| Medium | Medium | B601 | `core/server_home.py` | 265 | Paramiko `exec_command` — possible shell injection if input unsanitized |
+| Medium | Medium | B601 | `core/server_home.py` | 298 | Paramiko `exec_command` — possible shell injection if input unsanitized |
+| Medium | Medium | B601 | `core/server_home.py` | 302 | Paramiko `exec_command` — possible shell injection if input unsanitized |
+| Medium | Medium | B601 | `core/server_home.py` | 306 | Paramiko `exec_command` — possible shell injection if input unsanitized |
+| Medium | Medium | B601 | `core/server_home.py` | 312 | Paramiko `exec_command` — possible shell injection if input unsanitized |
+
+**Totals (by severity):** Low: 365 / Medium: 11 / High: 0
+
+---
+
+## 🔍 Secret Scan
+
+No secrets detected. Pattern scan covered `*.py`, `*.json`, `*.yaml`, `*.yml` excluding `tests/`, `docs/`, `.git/`, `logs/`.
+
+---
+
+## Delta vs 前日
+
+前日ログ (`logs/security/2026-07-05.md`) が存在しないため差分比較不可。本日が初回監査記録。
+
+---
+
+## Recommendations (優先度順)
+
+1. **[HIGH] paramiko CVE-2026-44405 対応** — `paramiko>=3.x` をコミット `a448945` 以降のパッチ版に更新するか、SSH 接続設定で `disabled_algorithms={'pubkeys': ['rsa-sha2-256', 'rsa-sha2-512']}` を明示して SHA-1 を無効化する。upstream fix がリリースされ次第 requirements.txt 下限を引き上げること。
+
+2. **[HIGH] diskcache CVE-2025-69872 継続監視** — `_secure_cache_dir()` で mitigated 済みだが、upstream に修正版がリリースされた時点で即座に更新。それまでキャッシュディレクトリのファイルシステム ACL を確認し、非 ai-chan プロセスの書き込みを禁止する。
+
+3. **[MEDIUM] B608 SQL injection リスク軽減** — `core/conversation_search.py:306` および `:368` の f-string クエリを SQLite パラメータバインディング (`?` プレースホルダ) に置換。テーブル名・カラム名は allowlist 検証済みのため実害は低いが、コードレビューで明示的に確認。
+
+4. **[MEDIUM] B310 urllib.request.urlopen スキーム検証** — `core/github_learner.py`, `core/image_gen.py`, `core/research_agent.py` 各所で `urllib.parse.urlparse` によるスキーム検証 (`https` のみ許可) を呼び出し前に追加。既存の `# noqa: S310` コメントを技術的根拠付きに更新。
+
+5. **[MEDIUM] B601 Paramiko exec_command 入力サニタイズ** — `core/server_home.py` の `exec_command` 呼び出し箇所でコマンド文字列が外部入力を含まないことを単体テストでカバー。固定文字列 (`"echo ok"`, `"uptime -p"` 等) は実害なしだが、将来の可変コマンド拡張に備えて allowlist パターンを関数シグネチャコメントに明記する。
+
+---
+
+<details>
+<summary>Raw Outputs</summary>
+
+### pip-audit (text)
+
+```
+Found 2 known vulnerabilities in 2 packages
+Name      Version ID             Fix Versions
+--------- ------- -------------- ------------
+paramiko  3.5.1   CVE-2026-44405
+diskcache 5.6.3   CVE-2025-69872
+```
+
+### bandit (summary)
+
+```
+Run started: 2026-07-06 00:11:56.226962+00:00
+
+Code scanned:
+    Total lines of code: 54471
+    Total lines skipped (#nosec): 0
+    Total potential issues skipped (specifically disabled): 10
+
+Run metrics:
+    Total issues (by severity):
+        Low: 365 / Medium: 11 / High: 0
+    Total issues (by confidence):
+        Low: 1 / Medium: 10 / High: 365
+```
+
+### pip list --outdated (system pip)
+
+```
+Package            Version   Latest    Type
+------------------ --------- --------- -----
+argcomplete        3.1.4     3.7.0     wheel
+blinker            1.7.0     1.9.0     wheel
+certifi            2026.2.25 2026.6.17 wheel
+charset-normalizer 3.4.6     3.4.7     wheel
+conan              2.27.0    2.30.0    wheel
+cryptography       41.0.7    49.0.0    wheel
+dbus-python        1.3.2     1.4.0     sdist
+httplib2           0.20.4    0.32.0    wheel
+idna               3.11      3.18      wheel
+launchpadlib       1.11.0    2.1.0     wheel
+lazr.uri           1.0.6     1.0.8     wheel
+oauthlib           3.2.2     3.3.1     wheel
+packaging          24.0      26.2      wheel
+patch-ng           1.18.1    1.19.1    wheel
+pip                24.0      26.1.2    wheel
+PyGObject          3.48.2    3.56.3    sdist
+PyJWT              2.7.0     2.13.0    wheel
+pyparsing          3.1.1     3.3.2     wheel
+PyYAML             6.0.1     6.0.3     wheel
+requests           2.33.1    2.34.2    wheel
+setuptools         68.1.2    83.0.0    wheel
+six                1.16.0    1.17.0    wheel
+urllib3            2.6.3     2.7.0     wheel
+wadllib            1.3.6     2.1.0     wheel
+wheel              0.42.0    0.47.0    wheel
+xmltodict          0.13.0    1.0.4     wheel
+yq                 3.1.0     4.1.1     wheel
+```
+
+</details>


### PR DESCRIPTION
# 🛡 Security Audit Report — 2026-07-06

| Item | Value |
|------|-------|
| Date (UTC) | 2026-07-06 |
| Commit SHA | `40bb06efeb35b72f5823fd6a27c9db2ad49f896c` |
| pip-audit | 2.10.1 |
| bandit | 1.9.4 |
| Python | 3.11.15 |

---

## Summary

| Scanner | CRITICAL | HIGH | MEDIUM | LOW |
|---------|----------|------|--------|-----|
| pip-audit | 0 | 2 | 0 | 0 |
| bandit | 0 | 0 | 11 | 365 |
| secrets | — | — | 0 | — |
| outdated (major) | — | — | — | 8 |

---

## 🚨 Critical / High Findings

| CVE | Package | Installed | Fix Version | Description |
|-----|---------|-----------|-------------|-------------|
| CVE-2026-44405 | paramiko | 3.5.1 | *(none upstream)* | In Paramiko through 4.0.0 before a448945, rsakey.py allows the SHA-1 algorithm — cryptographic weakness enabling downgrade attacks |
| CVE-2025-69872 | diskcache | 5.6.3 | *(none upstream)* | DiskCache pickle RCE via cache directory write access. **Mitigated** locally by `_secure_cache_dir()`. |

> ⚠ paramiko CVE-2026-44405 has no upstream fix version. Consider patching to commit `a448945` or disabling RSA/SHA-1 in SSH client config.

---

## ⚠ Outdated Dependencies (Major Bumps — system pip)

cryptography 41→49, setuptools 68→83, packaging 24→26, pip 24→26, launchpadlib 1→2, wadllib 1→2, xmltodict 0→1, yq 3→4
(All are system-pip packages; project requirements.txt dependencies are satisfied at current versions.)

---

## 📋 Bandit Findings (Medium × 11)

| Issue ID | File | Line | Description |
|----------|------|------|-------------|
| B608 | `core/conversation_search.py` | 306 | SQL injection via f-string |
| B608 | `core/conversation_search.py` | 368 | SQL injection via string concat |
| B310 | `core/github_learner.py` | 180 | urlopen scheme audit |
| B310 | `core/image_gen.py` | 156 | urlopen scheme audit |
| B310 | `core/research_agent.py` | 198 | urlopen scheme audit |
| B601 | `core/server_home.py` | 241,265,298,302,306,312 | paramiko exec_command (×6) |

---

## 🔍 Secret Scan

No secrets detected.

---

## Recommendations (優先度順)

1. **[HIGH]** paramiko CVE-2026-44405 — patch to commit `a448945` or add `disabled_algorithms` to SSH config
2. **[HIGH]** diskcache CVE-2025-69872 — update when upstream fix lands; verify cache dir ACL restricts writes to ai-chan process only
3. **[MEDIUM]** B608 — migrate SQL f-strings to parameterised queries in `core/conversation_search.py`
4. **[MEDIUM]** B310 — add `urlparse` scheme validation before `urlopen` calls
5. **[MEDIUM]** B601 — document exec_command allowlist pattern in `core/server_home.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9MDUq4bJyqf9ymHJ4C1VF)_